### PR TITLE
update BSON due to vulnerability, minor changes

### DIFF
--- a/lib/bloom/sbbf.ts
+++ b/lib/bloom/sbbf.ts
@@ -1,5 +1,3 @@
-import TypedArray = NodeJS.TypedArray;
-
 import parquet_thrift from "../../gen-nodejs/parquet_types";
 import Long = require('long')
 import XxHasher from "./xxhasher"

--- a/lib/codec/plain.js
+++ b/lib/codec/plain.js
@@ -49,7 +49,6 @@ function decodeValues_INT32(cursor, count) {
 function encodeValues_INT64(values) {
   let buf = Buffer.alloc(8 * values.length);
   for (let i = 0; i < values.length; i++) {
-    //console.log(typeof values[i]);
     buf.writeBigInt64LE(BigInt(values[i]), i*8);
   }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -292,13 +292,11 @@ function fromPrimitive_JSON(value) {
 }
 
 function toPrimitive_BSON(value) {
-  var encoder = new BSON();
-  return Buffer.from(encoder.serialize(value));
+  return Buffer.from(BSON.serialize(value));
 }
 
 function fromPrimitive_BSON(value) {
-  var decoder = new BSON();
-  return decoder.deserialize(value);
+  return BSON.deserialize(value);
 }
 
 function toPrimitive_TIME_MILLIS(value) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/thrift": "^0.10.10",
         "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
-        "bson": "^2.0.8",
+        "bson": "4.4.0",
         "cross-fetch": "^3.1.4",
         "esbuild": "^0.12.11",
         "events": "^3.3.0",
@@ -2268,7 +2268,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2418,12 +2417,37 @@
       }
     },
     "node_modules/bson": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.8.tgz",
-      "integrity": "sha512-0F0T3gHeOwJzHWcN60BZomqj5hCBDRk4b3fANuruvDTnyJJ8sggABKSaePM2F34THNZZSIlB2P1mk2nQWgBr9w==",
-      "deprecated": "Fixed a critical issue with BSON serialization documented in CVE-2019-2391, see https://bit.ly/2KcpXdo for more details",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.4.0.tgz",
+      "integrity": "sha512-uX9Zqzv2DpFXJgQOWKD8nbf0dTQV57WM8eiXDXVWeJYgiu/zIRz61OGLJKwbfSEEjZJ+AgS+7TUT7Y8EloTaqQ==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/bson/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer": {
@@ -3285,7 +3309,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7711,8 +7734,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -7811,9 +7833,23 @@
       }
     },
     "bson": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.8.tgz",
-      "integrity": "sha512-0F0T3gHeOwJzHWcN60BZomqj5hCBDRk4b3fANuruvDTnyJJ8sggABKSaePM2F34THNZZSIlB2P1mk2nQWgBr9w=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.4.0.tgz",
+      "integrity": "sha512-uX9Zqzv2DpFXJgQOWKD8nbf0dTQV57WM8eiXDXVWeJYgiu/zIRz61OGLJKwbfSEEjZJ+AgS+7TUT7Y8EloTaqQ==",
+      "requires": {
+        "buffer": "^5.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
     },
     "buffer": {
       "version": "6.0.3",
@@ -8449,8 +8485,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/thrift": "^0.10.10",
     "assert": "^2.0.0",
     "browserify-zlib": "^0.2.0",
-    "bson": "^2.0.8",
+    "bson": "4.4.0",
     "cross-fetch": "^3.1.4",
     "esbuild": "^0.12.11",
     "events": "^3.3.0",


### PR DESCRIPTION
# Problem
Fixes to small issues found while making this work in-browser.

Change summary:
---------------
* Update bson package from 2.0.8 to 4.4.0 due to a vulnerability in v2.  The interface changed, so update the files that use the package.
* Remove an unused TypeArray import.
* Remove a stray comment.

Steps to Verify:
----------------
CI should be passing.