### PR TITLE
add cjs and ejm builds

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -1,26 +1,41 @@
+const esbuild = require('esbuild')
 const path = require("path")
 const {compressionBrowserPlugin, wasmPlugin} = require("./esbuild-plugins");
 // esbuild has TypeScript support by default
-const outfile = 'parquet-bundle.min.js'
-require('esbuild')
-    .build({
-        bundle: true,
-        entryPoints: ['parquet.js'],
-        outdir: path.resolve(__dirname, "dist","browser"),
-        define: {
-            "process.env.NODE_DEBUG": false,
-            "process.env.NODE_ENV": "\"production\"",
-            global: "window"
-        },
+const baseConfig = {
+    bundle: true,
+    entryPoints: ['parquet.js'],
+    define: {
+        "process.env.NODE_DEBUG": false,
+        "process.env.NODE_ENV": "\"production\"",
+        global: "window"
+    },
+    inject: ['./esbuild-shims.js'],
+    minify: true,
+    platform: 'browser',  // default
+    plugins: [compressionBrowserPlugin, wasmPlugin],
+    target: "es2020"  // default
+};
+const targets = [
+    {
+        ...baseConfig,
         globalName: 'parquetjs',
-        inject: ['./esbuild-shims.js'],
-        minify: true,
-        platform: 'browser',  // default
-        plugins: [compressionBrowserPlugin, wasmPlugin],
-        target: "esnext"  // default
-    })
-    .then(res => {
-        if (!res.warnings.length) {
+        outdir: path.resolve(__dirname, "dist","browser"),
+    },
+    {
+        ...baseConfig,
+        format: "esm",
+        outfile: path.resolve(__dirname, "dist","browser","parquet.esm.js"),
+    },
+    {
+        ...baseConfig,
+        format: "cjs",
+        outfile: path.resolve(__dirname, "dist","browser","parquet.cjs.js"),
+    }
+]
+Promise.all(targets.map(esbuild.build))
+    .then(results => {        
+        if (results.reduce((m,r)=>m && !r.warnings.length, true)) {
             console.log("built with no errors or warnings")
         }
     })


### PR DESCRIPTION
### Motivation

In some packages we may need a common.js or ESM build as well as the default IIFC build.

### What's changed

This PR adds those build targets.