### PR TITLE
Added test cases for types and fixed bigint precision

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -469,7 +469,7 @@ function fromPrimitive_INTERVAL(value) {
 
 function checkValidValue(lowerRange, upperRange, v, bigV) {
   if (bigV < lowerRange || bigV > upperRange || isNaN(v)) {
-    throw error
+    throw "invalid value"
   }
 }
 

--- a/test/types.js
+++ b/test/types.js
@@ -154,10 +154,10 @@ describe("toPrimitive INT* should throw when given invalid value", () => {
         })
     }),
     describe("Testing toPrimitive_INT96 values", () => {
-        it('toPrimitive(UINT_64, 9999999999999999999999) is too large', () => {
+        it('toPrimitive(UINT_96, 9999999999999999999999) is too large', () => {
             assert.throws(() => toPrimitive('INT_96',9999999999999999999999))
         }),
-        it('toPrimitive(UINT_64, -9999999999999999999999) is too small', () => {
+        it('toPrimitive(UINT_96, -9999999999999999999999) is too small', () => {
             assert.throws(() => toPrimitive('INT_96',-9999999999999999999999))
         }),
         it('toPrimitive(UINT_96, "asd12@!$1") is given gibberish and should throw', () => {


### PR DESCRIPTION
Problem
=======
https://www.pivotaltracker.com/n/projects/2436354/stories/179388808
When you pass a large bigint to parquet, it gets converted to a number and loses precision
My solution was to check if the value sent was a big int or string and send back a bigint within the types.js file


Change summary:
---------------
-I included a check to see if a bigint was sent through and would return the value if it was.
-If it was a string, I also converted that to a bigint instead of an number because of the potential it could be a large number that cant be held by a number
-Created test cases for types to check my values
-Changed the checks on the value of the number sent to check the bigint and not the parsedInt
