### PR TITLE
[Issue #41] - Slimmed down FixedTFramedTransport class

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -4,38 +4,9 @@ import fs, { WriteStream } from 'fs'
 import * as parquet_thrift from '../gen-nodejs/parquet_types'
 import { NewFileMetaData } from './types/types'
 
-/** We need to use a patched version of TFramedTransport where
-  * readString returns the original buffer instead of a string if the 
-  * buffer can not be safely encoded as utf8 (see http://bit.ly/2GXeZEF)
-  */
-
-
 type Enums = typeof parquet_thrift.Encoding | typeof parquet_thrift.FieldRepetitionType | typeof parquet_thrift.Type | typeof parquet_thrift.CompressionCodec | typeof parquet_thrift.PageType | typeof parquet_thrift.ConvertedType;
  
-type ThriftObject = NewFileMetaData | parquet_thrift.PageHeader | parquet_thrift.BloomFilterHeader | parquet_thrift.OffsetIndex | parquet_thrift.ColumnIndex | NewFileMetaData;
-
-// May not be needed anymore, Issue at https://github.com/LibertyDSNP/parquetjs/issues/41
-class fixedTFramedTransport extends thrift.TFramedTransport {
-  inBuf: Buffer
-  readPos: number
-  constructor(inBuf: Buffer) {
-    super(inBuf)
-    this.inBuf = inBuf
-    this.readPos = 0
-  }
-
-  readString(len = 0): string {
-    this.ensureAvailable(len);
-    var buffer = this.inBuf.slice(this.readPos, this.readPos + len);
-    var str = this.inBuf.toString('utf8', this.readPos, this.readPos + len);
-    this.readPos += len;
-    //@ts-ignore
-    return (Buffer.from(str).equals(buffer)) ? str : buffer;
-  }
-}
-
-
-/** Patch PageLocation to be three element array that has getters/setters
+type ThriftObject = NewFileMetaData | parquet_thrift.PageHeader | parquet_thrift.BloomFilterHeader | parquet_thrift.OffsetIndex | parquet_thrift.ColumnIndex | NewFileMetaData;/** Patch PageLocation to be three element array that has getters/setters
   * for each of the properties (offset, compressed_page_size, first_row_index)
   * This saves space considerably as we do not need to store the full variable
   * names for every PageLocation
@@ -106,7 +77,7 @@ export const decodeThrift = function(obj: ThriftObject, buf: Buffer, offset?: nu
     offset = 0
   }
 
-  var transport = new fixedTFramedTransport(buf);
+  var transport = new thrift.TFramedTransport(buf);
   transport.readPos = offset;
   var protocol = new thrift.TCompactProtocol(transport);
   //@ts-ignore, https://issues.apache.org/jira/browse/THRIFT-3872


### PR DESCRIPTION
This may not be necessary, since we have upgraded Thrift to a version above 0.9.2.

See https://github.com/apache/thrift/blob/master/CHANGES.md\#092

Problem
=======
Since upgrading to Thrift ^0.92, we no longer need to patch the TFramedTransport class. However, since the Thrift type definitions don't expose a def for `readPos` (despite exposing a class that implements that field), we still need a patch that defines an attribute for it.

Solution
=======
Since we need to use a `readPos` attribute in our readers, I've slimmed down the patch class to have the attributes we depend on.