### PR TITLE
Removed redundant reference to callback

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -342,7 +342,7 @@ class ParquetTransformer extends stream.Transform {
   }
 
   _flush(callback) {
-    this.writer.close(callback)
+    this.writer.close()
       .then(d => callback(null, d), callback);
   }
 


### PR DESCRIPTION
# Goal
The purpose of this PR is to prevent a stream's close method from calling the same callback multiple times.

# Implementation
It seems like we are passing our callback to the stream's close method (which calls it) and again to the promise that the close method returns. This PR removes the first call, and allow the stream's promise to solely handle invoking the callback.

with @aramikm 

# Notes
It looks like the original author of our Parquet stream implementation wanted the callback to be invoked regardless of whether the stream's close method threw an exception. I'm not sure this is a solid approach -- we may want the exception to surface instead of being passed to a promise rejection handler. Also, it's not guaranteed that a given callback will run the same if the argument passed to it in some cases is an error.

For now, this fix allows all tests to pass. We may want to investigate the above concerns later on.