### PR TITLE
[Issue-42]: Remove TS Ignored lines from Util.ts

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -27,23 +27,14 @@ type ThriftObject = NewFileMetaData | parquet_thrift.PageHeader | parquet_thrift
   * names for every PageLocation
   */
 
-// Issue at https://github.com/LibertyDSNP/parquetjs/issues/42
-const previousPageLocation = new parquet_thrift.PageLocation();
-//@ts-ignore
-const PageLocation = parquet_thrift.PageLocation.prototype = [];
-//@ts-ignore
-PageLocation.write = previousPageLocation.write;
-//@ts-ignore
-PageLocation.read = previousPageLocation.read;
-
 const getterSetter = (index: number) => ({
   get: function(this: Array<number>): number { return this[index]; },
   set: function(this: Array<number>, value: number): number { return this[index] = value;}
 });
 
-Object.defineProperty(PageLocation,'offset', getterSetter(0));
-Object.defineProperty(PageLocation,'compressed_page_size', getterSetter(1));
-Object.defineProperty(PageLocation,'first_row_index', getterSetter(2));
+Object.defineProperty(parquet_thrift.PageLocation.prototype,'offset', getterSetter(0));
+Object.defineProperty(parquet_thrift.PageLocation.prototype,'compressed_page_size', getterSetter(1));
+Object.defineProperty(parquet_thrift.PageLocation.prototype,'first_row_index', getterSetter(2));
 
 /**
  * Helper function that serializes a thrift object into a buffer


### PR DESCRIPTION
Problem
=======
The purpose of this PR is to remove the places where we mutate `PageLocation`'s prototype. Since the `PageLocation` type definition does not declare a `read` or `write` member, we were forced to `@ts-ignore` it.

Solution
========
It seems like the `offset`, `compressed_page_size` and `first_row_index` members are explicitly declared on the type definitions. So to satisfy the original author's interface def, I've left the lines of code where we define these members on our PageLocation instance. If this is a bad idea, please comment.