### PR TITLE
removed force32

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -45,28 +45,6 @@ Object.defineProperty(PageLocation,'offset', getterSetter(0));
 Object.defineProperty(PageLocation,'compressed_page_size', getterSetter(1));
 Object.defineProperty(PageLocation,'first_row_index', getterSetter(2));
 
-// Dangerous code, investigate removal, Issue at https://github.com/LibertyDSNP/parquetjs/issues/43
-export const force32 = function() {
-  const protocol = thrift.TCompactProtocol.prototype;
-  //@ts-ignore
-  protocol.zigzagToI64 = protocol.zigzagToI32;
-  //@ts-ignore
-  protocol.readVarint64 = protocol.readVarint32 = function() {
-    let lo = 0;
-    let shift = 0;
-    let b;
-    while (true) {
-      b = protocol.readByte();
-      lo = lo | ((b & 0x7f) << shift);
-      shift += 7;
-      if (!(b & 0x80)) {
-        break;
-      }
-    }
-    return lo;
-  };
-}
-
 /**
  * Helper function that serializes a thrift object into a buffer
  */

--- a/parquet.js
+++ b/parquet.js
@@ -12,5 +12,4 @@ module.exports = {
   ParquetTransformer: writer.ParquetTransformer,
   ParquetSchema: schema.ParquetSchema,
   ParquetShredder: shredder,
-  force32: util.force32
 };


### PR DESCRIPTION
Problem
=======
We currently have a function force32 that forces 64bit numbers into 32bit. This is dangerous because we want parquetjs to handle 64 bit numbers. We should look into removing this function.

issue https://github.com/LibertyDSNP/parquetjs/issues/43

Change summary:
---------------
* removed force32

Notes
---------------
I did not find any usages in SDK or any other repositories.