### PR TITLE
Support async iteration in the reader

### DIFF
--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -218,6 +218,26 @@ class ParquetReader {
   }
 
   /**
+   * Support `for await` iterators on the reader object
+   * Uses `ParquetCursor` still under the hood.
+   *
+   * ```js
+   *  for await (const record of reader) {
+   *    console.log(record);
+   *  }
+   * ```
+   */
+  async* [Symbol.asyncIterator]() {
+    const cursor = this.getCursor();
+    let record = null;
+    while (record = await cursor.next()) {
+      yield record;
+    }
+}
+
+
+
+  /**
    * Return a cursor to the file. You may open more than one cursor and use
    * them concurrently. All cursors become invalid once close() is called on
    * the reader object.
@@ -251,7 +271,7 @@ class ParquetReader {
 
   /**
    * Return the number of rows in this file. Note that the number of rows is
-   * not neccessarily equal to the number of rows in each column.
+   * not necessarily equal to the number of rows in each column.
    */
   getRowCount() {
     return this.metadata!.num_rows;

--- a/test/reader.js
+++ b/test/reader.js
@@ -1,5 +1,6 @@
 "use strict";
 const chai = require("chai");
+const path = require("path");
 const assert = chai.assert;
 const parquet = require("../parquet.js");
 const server = require("./mocks/server");
@@ -92,4 +93,19 @@ describe("ParquetReader", () => {
       assert.deepEqual(null, await cursor.next());
     });
   });
+
+  describe("#asyncIterator", () => {
+    it("responds to for await", async () => {
+      const reader = await parquet.ParquetReader.openFile(
+        path.join(__dirname,'test-files','fruits.parquet')
+      );
+
+      let counter = 0;
+      for await(const record of reader) {
+        counter++;
+      }
+
+      assert.equal(counter, 40000);
+    })
+  })
 });


### PR DESCRIPTION
Problem
=======

Cursors are a pain to deal with. `for await` is easier for many iteration needs.

Solution
========

Added `Symbol.asyncIterator` to `ParquetReader`.

Closes: #53

Steps to Verify:
----------------
1. Test should run

```javascript
const reader = await parquet.ParquetReader.openFile('test.parquet', {});

for await (const record of reader) {
  console.log(record);
}

await reader.close();
```