### PR TITLE
Removed async keyword from BufferReader.read

### DIFF
--- a/lib/bufferReader.ts
+++ b/lib/bufferReader.ts
@@ -36,7 +36,7 @@ export default class BufferReader {
     this.queue = [];
   }
 
-  async read(offset: number, length: number): Promise<Buffer> {
+  read(offset: number, length: number): Promise<Buffer> {
     if (!this.scheduled) {
       this.scheduled = true;
       setTimeout( () => {


### PR DESCRIPTION
Problem
=======
This PR removes the async keyword from the `BufferReader.read` method.

Closes #45 