### PR TITLE
Chore/ts writer take2

### DIFF
--- a/lib/bloomFilterIO/bloomFilterReader.ts
+++ b/lib/bloomFilterIO/bloomFilterReader.ts
@@ -8,14 +8,7 @@ const filterColumnChunksWithBloomFilters = (
   columnChunkDataCollection: Array<ColumnChunkData>
 ) => {
   return columnChunkDataCollection.filter((columnChunk) => {
-    const {
-      column: {
-        meta_data: {
-          bloom_filter_offset: { buffer: bloomFilterOffsetBuffer },
-        },
-      },
-    } = columnChunk;
-    return bloomFilterOffsetBuffer;
+    return columnChunk.column.meta_data?.bloom_filter_offset;
   });
 };
 
@@ -38,20 +31,15 @@ const toInteger = (buffer: Buffer) => {
 export const parseBloomFilterOffsets = (
   ColumnChunkDataCollection: Array<ColumnChunkData>
 ): Array<bloomFilterOffsetData> => {
-  return ColumnChunkDataCollection.map((columnChunkData) => {
+  return ColumnChunkDataCollection.map(({rowGroupIndex,column}) => {
     const {
-      column: {
-        meta_data: {
-          bloom_filter_offset: { buffer: bloomFilterOffsetBuffer },
-          path_in_schema: pathInSchema,
-        },
-      },
-      rowGroupIndex,
-    } = columnChunkData;
+        bloom_filter_offset: bloomOffset,
+        path_in_schema: pathInSchema,
+      } = column.meta_data || {};
 
     return {
-      offsetBytes: toInteger(bloomFilterOffsetBuffer),
-      columnName: pathInSchema.join(","),
+      offsetBytes: bloomOffset!.toNumber(false),
+      columnName: pathInSchema!.join(","),
       rowGroupIndex,
     };
   });

--- a/lib/bloomFilterIO/bloomFilterReader.ts
+++ b/lib/bloomFilterIO/bloomFilterReader.ts
@@ -38,7 +38,7 @@ export const parseBloomFilterOffsets = (
       } = column.meta_data || {};
 
     return {
-      offsetBytes: bloomOffset!.toNumber(false),
+      offsetBytes: toInteger(bloomOffset!.buffer),
       columnName: pathInSchema!.join(","),
       rowGroupIndex,
     };

--- a/lib/bloomFilterIO/bloomFilterWriter.ts
+++ b/lib/bloomFilterIO/bloomFilterWriter.ts
@@ -64,7 +64,7 @@ export const serializeFilterData = (params: serializeFilterDataParams) => {
 };
 
 export const setFilterOffset = (column: parquet_thrift.ColumnChunk, offset: Int64) => {
-  column.meta_data!.bloom_filter_offset = offset;
+  column.meta_data!.bloom_filter_offset = parquet_util.cloneInteger(offset);
 };
 
 export const getSerializedBloomFilterData = (

--- a/lib/bloomFilterIO/bloomFilterWriter.ts
+++ b/lib/bloomFilterIO/bloomFilterWriter.ts
@@ -4,10 +4,11 @@ import SplitBlockBloomFilter from "../bloom/sbbf";
 
 import { ColumnData, Offset, Block } from "../types/types";
 
-type createSBBFParams = {
+export type createSBBFParams = {
   numFilterBytes?: number;
   falsePositiveRate?: number;
   numDistinct?: number;
+  column?: any;
 };
 
 export const createSBBF = (params: createSBBFParams): SplitBlockBloomFilter => {

--- a/lib/bloomFilterIO/bloomFilterWriter.ts
+++ b/lib/bloomFilterIO/bloomFilterWriter.ts
@@ -2,7 +2,7 @@ import * as parquet_util from "../util";
 import parquet_thrift from "../../gen-nodejs/parquet_types";
 import SplitBlockBloomFilter from "../bloom/sbbf";
 
-import { ColumnData, Block } from "../types/types";
+import { Block } from "../types/types";
 import Int64 from 'node-int64'
 
 export type createSBBFParams = {
@@ -63,7 +63,7 @@ export const serializeFilterData = (params: serializeFilterDataParams) => {
   return Buffer.concat([serializedFilterHeaders, serializedFilterBlocks]);
 };
 
-export const setFilterOffset = (column: ColumnData, offset: Int64) => {
+export const setFilterOffset = (column: parquet_thrift.ColumnChunk, offset: Int64) => {
   column.meta_data.bloom_filter_offset = offset;
 };
 

--- a/lib/bloomFilterIO/bloomFilterWriter.ts
+++ b/lib/bloomFilterIO/bloomFilterWriter.ts
@@ -2,7 +2,8 @@ import * as parquet_util from "../util";
 import parquet_thrift from "../../gen-nodejs/parquet_types";
 import SplitBlockBloomFilter from "../bloom/sbbf";
 
-import { ColumnData, Offset, Block } from "../types/types";
+import { ColumnData, Block } from "../types/types";
+import Int64 from 'node-int64'
 
 export type createSBBFParams = {
   numFilterBytes?: number;
@@ -62,7 +63,7 @@ export const serializeFilterData = (params: serializeFilterDataParams) => {
   return Buffer.concat([serializedFilterHeaders, serializedFilterBlocks]);
 };
 
-export const setFilterOffset = (column: ColumnData, offset: Offset) => {
+export const setFilterOffset = (column: ColumnData, offset: Int64) => {
   column.meta_data.bloom_filter_offset = offset;
 };
 

--- a/lib/bloomFilterIO/bloomFilterWriter.ts
+++ b/lib/bloomFilterIO/bloomFilterWriter.ts
@@ -64,7 +64,7 @@ export const serializeFilterData = (params: serializeFilterDataParams) => {
 };
 
 export const setFilterOffset = (column: parquet_thrift.ColumnChunk, offset: Int64) => {
-  column.meta_data.bloom_filter_offset = offset;
+  column.meta_data!.bloom_filter_offset = offset;
 };
 
 export const getSerializedBloomFilterData = (

--- a/lib/bufferReader.ts
+++ b/lib/bufferReader.ts
@@ -1,13 +1,13 @@
 import { Statistics } from "gen-nodejs/parquet_types"
 import { ParquetEnvelopeReader } from "./reader"
-import { NewFileMetaData } from "./types/types"
+import { FileMetaDataExt } from "./types/types"
 
 export interface BufferReaderOptions {
   maxSpan?: number,
   maxLength?: number,
   queueWait?: number
   default_dictionary_size?: number;
-  metadata?: NewFileMetaData
+  metadata?: FileMetaDataExt
   rawStatistics?: Statistics
 }
 

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -37,7 +37,7 @@ const PARQUET_RDLVL_ENCODING = 'RLE';
  */
 class ParquetCursor  {
 
-  metadata: NewFileMetaData;
+  metadata: FileMetaDataExt;
   envelopeReader: ParquetEnvelopeReader;
   schema: parquet_schema.ParquetSchema;
   columnList: Array<Array<unknown>>;
@@ -49,7 +49,7 @@ class ParquetCursor  {
    * advanced and internal use cases. Consider using getCursor() on the
    * ParquetReader instead
    */
-  constructor( metadata: NewFileMetaData, envelopeReader: ParquetEnvelopeReader, schema: parquet_schema.ParquetSchema, columnList: Array<Array<unknown>>) {
+  constructor( metadata: FileMetaDataExt, envelopeReader: ParquetEnvelopeReader, schema: parquet_schema.ParquetSchema, columnList: Array<Array<unknown>>) {
     this.metadata = metadata;
     this.envelopeReader = envelopeReader;
     this.schema = schema;
@@ -100,7 +100,7 @@ class ParquetCursor  {
 export class ParquetReader {
 
   envelopeReader: ParquetEnvelopeReader | null;
-  metadata: NewFileMetaData | null;
+  metadata: FileMetaDataExt | null;
   schema: parquet_schema.ParquetSchema
 
   /**
@@ -160,7 +160,7 @@ export class ParquetReader {
    * and internal use cases. Consider using one of the open{File,Buffer} methods
    * instead
    */
-  constructor(metadata: NewFileMetaData, envelopeReader: ParquetEnvelopeReader, opts: BufferReaderOptions) {
+  constructor(metadata: FileMetaDataExt, envelopeReader: ParquetEnvelopeReader, opts: BufferReaderOptions) {
     opts = opts || {};
     if (metadata.version != PARQUET_VERSION) {
       throw 'invalid parquet version';
@@ -363,7 +363,7 @@ export class ParquetEnvelopeReader {
   id: number;
   fileSize: Function | number;
   default_dictionary_size: number;
-  metadata?: NewFileMetaData;
+  metadata?: FileMetaDataExt;
   schema?: parquet_schema.ParquetSchema
 
   static async openFile(filePath: string | Buffer | URL, options: BufferReaderOptions) {
@@ -447,7 +447,7 @@ export class ParquetEnvelopeReader {
     return new ParquetEnvelopeReader(readFn, closeFn, filesize, options);
   }
 
-  constructor(readFn: (offset: number, length: number, file?: string) => Promise<Buffer> , closeFn: () => unknown, fileSize: Function | number, options: BufferReaderOptions, metadata?: NewFileMetaData) {
+  constructor(readFn: (offset: number, length: number, file?: string) => Promise<Buffer> , closeFn: () => unknown, fileSize: Function | number, options: BufferReaderOptions, metadata?: FileMetaDataExt) {
     options = options || {};
     this.readFn = readFn;
     this.id = ++ParquetEnvelopeReaderIdCounter;

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -184,11 +184,11 @@ export class ParquetReader {
       metadata.row_groups.forEach(rowGroup => {
         rowGroup.columns.forEach(column => {
           if (column.offsetIndex) {
-            column.offsetIndex.page_locations.forEach(d => {
+            column.offsetIndex.then(offset => (offset.page_locations.forEach(d => {
               if (Array.isArray(d)) {
                 Object.setPrototypeOf(d,parquet_thrift.PageLocation.prototype);
               }
-            });
+            })));
           }
         });
       });

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -610,7 +610,7 @@ export class ParquetEnvelopeReader {
         continue;
       }
 
-      buffer.columnData[colKey.join(',')] = await this.readColumnChunk(schema, colChunk);
+      buffer.columnData![colKey.join(',')] = await this.readColumnChunk(schema, colChunk);
     }
 
     return buffer;

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -573,7 +573,7 @@ export class ParquetEnvelopeReader {
       column.meta_data.data_page_offset = page.offset;
       column.meta_data.total_compressed_size =  new Int64(page.compressed_page_size);
     } else {
-      const offsetIndex = await column.offsetIndex || await this.readOffsetIndex(column, null, opts);
+      const offsetIndex = await this.readOffsetIndex(column, null, opts);
       column.meta_data.data_page_offset = offsetIndex.page_locations[page as number].offset;
       column.meta_data.total_compressed_size =  new Int64(offsetIndex.page_locations[page as number].compressed_page_size);
     }

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -584,11 +584,11 @@ export class ParquetEnvelopeReader {
       if (isNaN(Number(page.offset)) || isNaN(page.compressed_page_size)) {
         throw Error('page offset and/or size missing');
       }
-      column.meta_data.data_page_offset = page.offset;
+      column.meta_data.data_page_offset = parquet_util.cloneInteger(page.offset);
       column.meta_data.total_compressed_size =  new Int64(page.compressed_page_size);
     } else {
       const offsetIndex = await this.readOffsetIndex(column, null, opts);
-      column.meta_data.data_page_offset = offsetIndex.page_locations[page as number].offset;
+      column.meta_data.data_page_offset = parquet_util.cloneInteger(offsetIndex.page_locations[page as number].offset);
       column.meta_data.total_compressed_size =  new Int64(offsetIndex.page_locations[page as number].compressed_page_size);
     }
     const chunk = await this.readColumnChunk(this.schema!, column);

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -681,7 +681,7 @@ export class ParquetEnvelopeReader {
     }
 
     let metadataBuf = await this.read(metadataOffset, metadataSize);
-    let metadata = new NewFileMetaData();
+    let metadata = new parquet_thrift.FileMetaData();
     parquet_util.decodeThrift(metadata, metadataBuf);
     return metadata;
   }

--- a/lib/shred.ts
+++ b/lib/shred.ts
@@ -28,7 +28,7 @@ import { Page, PageData, ParquetField } from './types/types';
 
 export interface RecordBuffer {
   columnData?: Record<string, PageData>
-  rowCount?: Int64,
+  rowCount?: number,
   pageRowCount?: number,
   pages?: Record<string,Page[]>
 }

--- a/lib/shred.ts
+++ b/lib/shred.ts
@@ -1,6 +1,6 @@
 import * as parquet_types from './types'
 import { ParquetSchema } from './schema'
-import { PageData, ParquetField } from './types/types';
+import { Page, PageData, ParquetField } from './types/types';
 
 /**
  * 'Shred' a record into a list of <value, repetition_level, definition_level>
@@ -27,10 +27,10 @@ import { PageData, ParquetField } from './types/types';
  */
 
 export interface RecordBuffer {
-  columnData: Record<string, PageData>
+  columnData?: Record<string, PageData>
   rowCount?: number,
   pageRowCount?: number,
-  pages?: Record<string,object>
+  pages?: Record<string,Page[]>
 }
 
 export const shredRecord = function(schema: ParquetSchema, record: Record<string, unknown>, buffer: RecordBuffer) {
@@ -73,7 +73,7 @@ export const shredRecord = function(schema: ParquetSchema, record: Record<string
   for (let field of schema.fieldList) {
     let path = field.path.join(',')
     let record = recordShredded[path];
-    let column = buffer.columnData[path];
+    let column = buffer.columnData![path];
 
     for (let i = 0; i < record.rlevels!.length; i++) {
       column.rlevels!.push(record.rlevels![i]);
@@ -83,9 +83,9 @@ export const shredRecord = function(schema: ParquetSchema, record: Record<string
       }
     }
 
-    [...recordShredded[path].distinct_values!].forEach(value => buffer.columnData[path].distinct_values!.add(value));
+    [...recordShredded[path].distinct_values!].forEach(value => buffer.columnData![path].distinct_values!.add(value));
 
-    buffer.columnData[path].count! += recordShredded[path].count!;
+    buffer.columnData![path].count! += recordShredded[path].count!;
   }
 };
 

--- a/lib/shred.ts
+++ b/lib/shred.ts
@@ -28,7 +28,7 @@ import { Page, PageData, ParquetField } from './types/types';
 
 export interface RecordBuffer {
   columnData?: Record<string, PageData>
-  rowCount?: number,
+  rowCount?: Int64,
   pageRowCount?: number,
   pages?: Record<string,Page[]>
 }

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -108,6 +108,8 @@ export interface ColumnChunkData {
 
 export interface ColumnChunkExt extends parquet_thrift.ColumnChunk{
     meta_data?: ColumnMetaDataExt
+    columnIndex?: Promise<ColumnIndex>
+    offsetIndex?: Promise<OffsetIndex>
 }
 export interface ColumnMetaDataExt extends parquet_thrift.ColumnMetaData {
     offsetIndex?: OffsetIndex

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -100,34 +100,22 @@ export interface ParquetBuffer {
 export interface ParquetRecord {
     [key: string]: any;
 }
-export interface ColumnData {
-    file_path: string,
-    file_offset: Int64,
-    meta_data: ColumnnMetaDataExt
-    offset_index_length?: number;
-    column_index_length?: number;
-    encrypted_column_metadata?: Buffer;
-    offsetIndex?: OffsetIndex;
-    offset_index_offset?: Int64;
-    columnIndex?: ColumnIndex;
-    column_index_offset?: Int64;
-}
 
 export interface ColumnChunkData {
     rowGroupIndex: number,
-    column: ColumnData
+    column: parquet_thrift.ColumnChunk
 }
 
-export interface ColumnnMetaDataExt extends ColumnMetaData {
+export interface ColumnChunkExt extends parquet_thrift.ColumnChunk{
+    meta_data?: ColumnMetaDataExt
+}
+export interface ColumnMetaDataExt extends parquet_thrift.ColumnMetaData {
     offsetIndex?: OffsetIndex
     columnIndex?: ColumnIndex
-
 }
 
-export declare class RowGroup {
-    columns: ColumnData[];
-    num_rows: number;
-    ordinal?: number;
+export interface RowGroupExt extends parquet_thrift.RowGroup {
+    columns: ColumnChunkExt[];
 }
 
 export declare class KeyValue {
@@ -157,7 +145,7 @@ export interface PageData {
     pageHeader?: PageHeader;
     count?: number;
     dictionary?: Array<unknown>
-    column?: ColumnData
+    column?: parquet_thrift.ColumnChunk
 }
 
 export declare class PageHeader {
@@ -207,19 +195,6 @@ export class NewPageHeader extends parquet_thrift.PageHeader {
       super()
     }
   }
-
-  export class NewRowGroup extends parquet_thrift.RowGroup {
-    //@ts-ignore
-    columns: ColumnData[];
-    //@ts-ignore
-    num_rows: number;
-    //@ts-ignore
-    ordinal?: number;
-    constructor() {
-      super()
-    }
-  }
-
 
 export type WriterOptions = {
     pageIndex?: boolean;

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -1,9 +1,10 @@
 // Lifted from https://github.com/kbajalc/parquets
 
 import parquet_thrift from "../../gen-nodejs/parquet_types";
-import { Statistics, OffsetIndex, ColumnIndex, PageType, DataPageHeader, DataPageHeaderV2, DictionaryPageHeader, IndexPageHeader, Type } from "../../gen-nodejs/parquet_types";
+import { Statistics, OffsetIndex, ColumnIndex, PageType, DataPageHeader, DataPageHeaderV2, DictionaryPageHeader, IndexPageHeader, Type, ColumnMetaData } from "../../gen-nodejs/parquet_types";
 import SplitBlockBloomFilter from "lib/bloom/sbbf";
 import { createSBBFParams } from "lib/bloomFilterIO/bloomFilterWriter";
+import Int64 from 'node-int64'
 
 export type ParquetCodec = 'PLAIN' | 'RLE';
 export type ParquetCompression = 'UNCOMPRESSED' | 'GZIP' | 'SNAPPY' | 'LZO' | 'BROTLI' | 'LZ4';
@@ -99,43 +100,17 @@ export interface ParquetBuffer {
 export interface ParquetRecord {
     [key: string]: any;
 }
-
-// export interface Offset {
-//     buffer: Buffer
-//     offset: number
-// }
-
-// todo: swap with int64 from node library
-export interface ColumnMetaData {
-    type: Type,
-    encodings: Array<any>,
-    path_in_schema: Array<string>,
-    codec: number,
-    num_values: number,
-    total_uncompressed_size: any,
-    total_compressed_size: any,
-    key_value_metadata: any,
-    data_page_offset: Offset,
-    index_page_offset: Offset,
-    dictionary_page_offset: Offset,
-    statistics: any,
-    encoding_stats: any,
-    bloom_filter_offset: Offset
-    columnIndex?: ColumnIndex;
-    offsetIndex?: OffsetIndex;
-}
-
 export interface ColumnData {
     file_path: string,
-    file_offset: Offset,
+    file_offset: Int64,
     meta_data: ColumnMetaData
     offset_index_length?: number;
     column_index_length?: number;
     encrypted_column_metadata?: Buffer;
     offsetIndex?: OffsetIndex;
-    offset_index_offset?: number;
+    offset_index_offset?: Int64;
     columnIndex?: ColumnIndex;
-    column_index_offset?: number;
+    column_index_offset?: Int64;
 }
 
 export interface ColumnChunkData {
@@ -245,7 +220,7 @@ export type WriterOptions = {
     pageSize?: number;
     useDataPageV2?: boolean;
     bloomFilters?: createSBBFParams[];
-    baseOffset?: number;
+    baseOffset?: Int64;
     rowGroupSize?: number;
     flags?: string;
     encoding?: BufferEncoding;

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -108,8 +108,8 @@ export interface ColumnChunkData {
 
 export interface ColumnChunkExt extends parquet_thrift.ColumnChunk{
     meta_data?: ColumnMetaDataExt
-    columnIndex?: Promise<ColumnIndex>
-    offsetIndex?: Promise<OffsetIndex>
+    columnIndex?: ColumnIndex | Promise<ColumnIndex>
+    offsetIndex?: OffsetIndex | Promise<OffsetIndex>
 }
 export interface ColumnMetaDataExt extends parquet_thrift.ColumnMetaData {
     offsetIndex?: OffsetIndex

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -179,13 +179,9 @@ export declare class PageHeader {
     getObject: (args: any) => PromiseS3
 }
 
-export class NewFileMetaData extends parquet_thrift.FileMetaData {
+export interface FileMetaDataExt extends parquet_thrift.FileMetaData {
     json?:JSON;
-    //@ts-ignore
-    row_groups: RowGroup[];
-    constructor() {
-      super()
-    }
+    row_groups: RowGroupExt[];
   }
 
 export class NewPageHeader extends parquet_thrift.PageHeader {

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -224,3 +224,16 @@ export class NewPageHeader extends parquet_thrift.PageHeader {
   }
   
   
+export type streamOptions = {
+    rowGroupSize?: number;
+    
+    flags?: string;
+    encoding?: BufferEncoding;
+    fd?: number;
+    mode?: number;
+    autoClose?: boolean;
+    emitClose?: boolean;
+    start?: number;
+    highWaterMark?: number;
+  }
+  

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -103,7 +103,7 @@ export interface ParquetRecord {
 export interface ColumnData {
     file_path: string,
     file_offset: Int64,
-    meta_data: ColumnMetaData
+    meta_data: ColumnnMetaDataExt
     offset_index_length?: number;
     column_index_length?: number;
     encrypted_column_metadata?: Buffer;
@@ -116,6 +116,12 @@ export interface ColumnData {
 export interface ColumnChunkData {
     rowGroupIndex: number,
     column: ColumnData
+}
+
+export interface ColumnnMetaDataExt extends ColumnMetaData {
+    offsetIndex?: OffsetIndex
+    columnIndex?: ColumnIndex
+
 }
 
 export declare class RowGroup {

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -100,11 +100,12 @@ export interface ParquetRecord {
     [key: string]: any;
 }
 
-export interface Offset {
-    buffer: Buffer
-    offset: number
-}
+// export interface Offset {
+//     buffer: Buffer
+//     offset: number
+// }
 
+// todo: swap with int64 from node library
 export interface ColumnMetaData {
     type: Type,
     encodings: Array<any>,
@@ -189,7 +190,7 @@ export declare class PageHeader {
     data_page_header_v2?: DataPageHeaderV2;
     offset?: number;
     headerSize?: number;
-  
+
       constructor(args?: { type: PageType; uncompressed_page_size: number; compressed_page_size: number; crc?: number; data_page_header?: DataPageHeader; index_page_header?: IndexPageHeader; dictionary_page_header?: DictionaryPageHeader; data_page_header_v2?: DataPageHeaderV2; });
   }
 
@@ -215,7 +216,7 @@ export class NewFileMetaData extends parquet_thrift.FileMetaData {
     row_groups: RowGroup[];
     constructor() {
       super()
-    } 
+    }
   }
 
 export class NewPageHeader extends parquet_thrift.PageHeader {
@@ -223,7 +224,7 @@ export class NewPageHeader extends parquet_thrift.PageHeader {
     headerSize?: number;
     constructor() {
       super()
-    } 
+    }
   }
 
   export class NewRowGroup extends parquet_thrift.RowGroup {
@@ -235,10 +236,10 @@ export class NewPageHeader extends parquet_thrift.PageHeader {
     ordinal?: number;
     constructor() {
       super()
-    } 
+    }
   }
 
-  
+
 export type WriterOptions = {
     pageIndex?: boolean;
     pageSize?: number;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -2,8 +2,7 @@ import { TTransportCallback } from "thrift";
 import thrift from "thrift"
 import fs, { WriteStream } from 'fs'
 import * as parquet_thrift from '../gen-nodejs/parquet_types'
-import { NewFileMetaData } from './types/types'
-import { streamOptions } from "./types/types";
+import { NewFileMetaData, WriterOptions } from './types/types'
 
 /**
  * We need to patch Thrift's TFramedTransport class bc the TS type definitions
@@ -21,8 +20,10 @@ class fixedTFramedTransport extends thrift.TFramedTransport {
 }
 
 type Enums = typeof parquet_thrift.Encoding | typeof parquet_thrift.FieldRepetitionType | typeof parquet_thrift.Type | typeof parquet_thrift.CompressionCodec | typeof parquet_thrift.PageType | typeof parquet_thrift.ConvertedType;
- 
-type ThriftObject = NewFileMetaData | parquet_thrift.PageHeader | parquet_thrift.BloomFilterHeader | parquet_thrift.OffsetIndex | parquet_thrift.ColumnIndex | NewFileMetaData;/** Patch PageLocation to be three element array that has getters/setters
+
+type ThriftObject = NewFileMetaData | parquet_thrift.PageHeader | parquet_thrift.ColumnMetaData | parquet_thrift.BloomFilterHeader | parquet_thrift.OffsetIndex | parquet_thrift.ColumnIndex | NewFileMetaData;
+
+/** Patch PageLocation to be three element array that has getters/setters
   * for each of the properties (offset, compressed_page_size, first_row_index)
   * This saves space considerably as we do not need to store the full variable
   * names for every PageLocation
@@ -40,7 +41,7 @@ Object.defineProperty(parquet_thrift.PageLocation.prototype,'first_row_index', g
 /**
  * Helper function that serializes a thrift object into a buffer
  */
-export const serializeThrift = function(obj: parquet_thrift.BloomFilterHeader) {
+export const serializeThrift = function(obj: ThriftObject) {
   let output:Array<Uint8Array> = []
 
   const callBack:TTransportCallback = function (buf: Buffer | undefined) {
@@ -168,7 +169,7 @@ export const osend = function(os: WriteStream) {
   });
 }
 
-export const osopen = function(path: string | Buffer | URL, opts?: string | streamOptions): Promise<WriteStream> {
+export const osopen = function(path: string | Buffer | URL, opts?: string | WriterOptions): Promise<WriteStream> {
   return new Promise((resolve, reject) => {
     let outputStream = fs.createWriteStream(path, opts);
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -3,6 +3,7 @@ import thrift from "thrift"
 import fs, { WriteStream } from 'fs'
 import * as parquet_thrift from '../gen-nodejs/parquet_types'
 import { NewFileMetaData } from './types/types'
+import { streamOptions } from "./types/types";
 
 /**
  * We need to patch Thrift's TFramedTransport class bc the TS type definitions
@@ -167,7 +168,7 @@ export const osend = function(os: WriteStream) {
   });
 }
 
-export const osopen = function(path: string | Buffer | URL, opts: string) {
+export const osopen = function(path: string | Buffer | URL, opts?: string | streamOptions): Promise<WriteStream> {
   return new Promise((resolve, reject) => {
     let outputStream = fs.createWriteStream(path, opts);
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -3,6 +3,7 @@ import thrift from "thrift"
 import fs, { WriteStream } from 'fs'
 import * as parquet_thrift from '../gen-nodejs/parquet_types'
 import { FileMetaDataExt, WriterOptions } from './types/types'
+import { Int64 } from "thrift";
 
 /**
  * We need to patch Thrift's TFramedTransport class bc the TS type definitions
@@ -204,3 +205,7 @@ export const fieldIndexOf = function(arr: Array<Array<unknown>>, elem: Array<unk
 
   return -1;
 }
+
+export const cloneInteger = (int: Int64) => {
+   return new Int64(int.valueOf());
+};

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -2,7 +2,7 @@ import { TTransportCallback } from "thrift";
 import thrift from "thrift"
 import fs, { WriteStream } from 'fs'
 import * as parquet_thrift from '../gen-nodejs/parquet_types'
-import { NewFileMetaData, WriterOptions } from './types/types'
+import { FileMetaDataExt, WriterOptions } from './types/types'
 
 /**
  * We need to patch Thrift's TFramedTransport class bc the TS type definitions
@@ -21,7 +21,7 @@ class fixedTFramedTransport extends thrift.TFramedTransport {
 
 type Enums = typeof parquet_thrift.Encoding | typeof parquet_thrift.FieldRepetitionType | typeof parquet_thrift.Type | typeof parquet_thrift.CompressionCodec | typeof parquet_thrift.PageType | typeof parquet_thrift.ConvertedType;
 
-type ThriftObject = NewFileMetaData | parquet_thrift.PageHeader | parquet_thrift.ColumnMetaData | parquet_thrift.BloomFilterHeader | parquet_thrift.OffsetIndex | parquet_thrift.ColumnIndex | NewFileMetaData;
+type ThriftObject = FileMetaDataExt | parquet_thrift.PageHeader | parquet_thrift.ColumnMetaData | parquet_thrift.BloomFilterHeader | parquet_thrift.OffsetIndex | parquet_thrift.ColumnIndex | FileMetaDataExt;
 
 /** Patch PageLocation to be three element array that has getters/setters
   * for each of the properties (offset, compressed_page_size, first_row_index)

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -40,7 +40,7 @@ const PARQUET_RDLVL_ENCODING = 'RLE';
  * buffering/batching for performance, so close() must be called after all rows
  * are written.
  */
-class ParquetWriter {
+export class ParquetWriter {
 
   schema: ParquetSchema;
   envelopeWriter: ParquetEnvelopeWriter | null;
@@ -187,7 +187,7 @@ class ParquetWriter {
  * intended for advanced and internal users; the writeXXX methods must be
  * called in the correct order to produce a valid file.
  */
-class ParquetEnvelopeWriter {
+export class ParquetEnvelopeWriter {
   schema: ParquetSchema
   write: Function;
   close: Function;
@@ -330,7 +330,7 @@ class ParquetEnvelopeWriter {
 /**
  * Create a parquet transform stream
  */
-class ParquetTransformer extends stream.Transform {
+export class ParquetTransformer extends stream.Transform {
 
   writer: ParquetWriter;
 

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -206,10 +206,10 @@ class ParquetEnvelopeWriter {
   static async openStream(schema: ParquetSchema, outputStream: WriteStream, opts: WriterOptions) {
     let writeFn = parquet_util.oswrite.bind(undefined, outputStream);
     let closeFn = parquet_util.osend.bind(undefined, outputStream);
-    return new ParquetEnvelopeWriter(schema, writeFn, closeFn, 0, opts);
+    return new ParquetEnvelopeWriter(schema, writeFn, closeFn, new Int64(0), opts);
   }
 
-  constructor(schema: ParquetSchema, writeFn: Function, closeFn: Function, fileOffset: number, opts: StreamOptions) {
+  constructor(schema: ParquetSchema, writeFn: Function, closeFn: Function, fileOffset: Int64, opts: StreamOptions) {
     this.schema = schema;
     this.write = writeFn;
     this.close = closeFn;

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -6,8 +6,9 @@ import * as parquet_codec from './codec'
 import * as parquet_compression from './compression'
 import * as parquet_types from './types'
 import * as bloomFilterWriter from "./bloomFilterIO/bloomFilterWriter"
-import { WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField } from './types/types'
+import { Offset, WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField } from './types/types'
 import { Options } from './codec/types'
+import Long from 'long'
 import { ParquetSchema } from './schema'
 import { WriteStream } from 'fs'
 import Int64 from 'node-int64'
@@ -181,7 +182,7 @@ class ParquetWriter {
 /**
  * Create a parquet file from a schema and a number of row groups. This class
  * performs direct, unbuffered writes to the underlying output stream and is
- * intendend for advanced and internal users; the writeXXX methods must be
+ * intended for advanced and internal users; the writeXXX methods must be
  * called in the correct order to produce a valid file.
  */
 class ParquetEnvelopeWriter {
@@ -189,13 +190,13 @@ class ParquetEnvelopeWriter {
   schema: ParquetSchema;
   write: Function;
   close: Function;
-  offset: number;
-  rowCount: number;
-  pageSize: number;
-  pageIndex: boolean;
-  useDataPageV2: boolean;
+  offset: Offset // TODO: was number, not quite sure if Offset is correct
+  rowCount: Int64
   rowGroups: RowGroup[]
-  bloomFilters: Record<string, SplitBlockBloomFilter>
+  pageSize: number;
+  useDataPageV2: boolean;
+  pageIndex: boolean;
+  bloomFilters: Record<string, SplitBlockBloomFilter> // TODO: OR filterCollection
 
   /**
    * Create a new parquet envelope writer that writes to the specified stream

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -227,7 +227,7 @@ class ParquetEnvelopeWriter {
   }
 
   writeSection(buf: Buffer) {
-    this.offset += new Offset() // buf.length;
+    this.offset.offset += buf.length;
     return this.write(buf);
   }
 

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -6,11 +6,12 @@ import * as parquet_codec from './codec'
 import * as parquet_compression from './compression'
 import * as parquet_types from './types'
 import * as bloomFilterWriter from "./bloomFilterIO/bloomFilterWriter"
-import { streamOptions } from './types/types'
-
-import Long from 'long'
+import { WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField } from './types/types'
+import { Options } from './codec/types'
 import { ParquetSchema } from './schema'
 import { WriteStream } from 'fs'
+import Int64 from 'node-int64'
+import SplitBlockBloomFilter from './bloom/sbbf'
 
 /**
  * Parquet File Magic String
@@ -42,17 +43,17 @@ const PARQUET_RDLVL_ENCODING = 'RLE';
 class ParquetWriter {
 
   schema: ParquetSchema;
-  envelopeWriter: ParquetEnvelopeWriter;
-  rowBuffer: unknown;
+  envelopeWriter: ParquetEnvelopeWriter | null;
+  rowBuffer: parquet_shredder.RecordBuffer;
   rowGroupSize: number;
   closed: boolean;
-  userMetadata: unknown;
+  userMetadata: Record<string, string>;
 
   /**
    * Convenience method to create a new buffered parquet writer that writes to
    * the specified file
    */
-  static async openFile(schema: ParquetSchema, path: string | Buffer | URL, opts?: string | streamOptions) {
+  static async openFile(schema: ParquetSchema, path: string | Buffer | URL, opts?: WriterOptions) {
     let outputStream = await parquet_util.osopen(path, opts);
     return ParquetWriter.openStream(schema, outputStream, opts);
   }
@@ -61,7 +62,7 @@ class ParquetWriter {
    * Convenience method to create a new buffered parquet writer that writes to
    * the specified stream
    */
-  static async openStream(schema: ParquetSchema, outputStream: WriteStream, opts?: string | streamOptions) {
+  static async openStream(schema: ParquetSchema, outputStream: WriteStream, opts?: WriterOptions) {
     if (!opts) {
       opts = {};
     }
@@ -77,11 +78,11 @@ class ParquetWriter {
   /**
    * Create a new buffered parquet writer for a given envelope writer
    */
-  constructor(schema: ParquetSchema, envelopeWriter: ParquetEnvelopeWriter, opts?: string | streamOptions) {
+  constructor(schema: ParquetSchema, envelopeWriter: ParquetEnvelopeWriter, opts?: WriterOptions) {
     this.schema = schema;
     this.envelopeWriter = envelopeWriter;
     this.rowBuffer = {};
-    this.rowGroupSize = (opts as streamOptions).rowGroupSize || PARQUET_DEFAULT_ROW_GROUP_SIZE;
+    this.rowGroupSize = (opts as WriterOptions).rowGroupSize || PARQUET_DEFAULT_ROW_GROUP_SIZE;
     this.closed = false;
     this.userMetadata = {};
 
@@ -97,7 +98,7 @@ class ParquetWriter {
    * Append a single row to the parquet file. Rows are buffered in memory until
    * rowGroupSize rows are in the buffer or close() is called
    */
-  async appendRow(row) {
+  async appendRow(row: Record<string, unknown>) {
     if (this.closed) {
       throw 'writer was closed';
     }
@@ -105,16 +106,16 @@ class ParquetWriter {
     parquet_shredder.shredRecord(this.schema, row, this.rowBuffer);
 
     const options = {
-      useDataPageV2: this.envelopeWriter.useDataPageV2,
-      bloomFilters: this.envelopeWriter.bloomFilters
+      useDataPageV2: this.envelopeWriter!.useDataPageV2,
+      bloomFilters: this.envelopeWriter!.bloomFilters
     };
-    if (this.rowBuffer.pageRowCount >= this.envelopeWriter.pageSize) {
+    if (this.rowBuffer.pageRowCount! >= this.envelopeWriter!.pageSize) {
       await encodePages(this.schema, this.rowBuffer, options);
     }
 
-    if (this.rowBuffer.rowCount >= this.rowGroupSize) {
+    if (this.rowBuffer.rowCount! >= this.rowGroupSize) {
       await encodePages(this.schema, this.rowBuffer, options);
-      await this.envelopeWriter.writeRowGroup(this.rowBuffer);
+      await this.envelopeWriter!.writeRowGroup(this.rowBuffer);
       this.rowBuffer = {};
     }
   }
@@ -125,24 +126,24 @@ class ParquetWriter {
    * method twice on the same object or add any rows after the close() method has
    * been called
    */
-  async close(callback) {
+  async close(callback: Function) {
     if (this.closed) {
       throw 'writer was closed';
     }
 
     this.closed = true;
 
-    if (this.rowBuffer.rowCount > 0 || this.rowBuffer.rowCount >= this.rowGroupSize) {
-      await encodePages(this.schema, this.rowBuffer, { useDataPageV2: this.envelopeWriter.useDataPageV2, bloomFilters: this.envelopeWriter.bloomFilters});
+    if (this.rowBuffer.rowCount! > 0 || this.rowBuffer.rowCount! >= this.rowGroupSize) {
+      await encodePages(this.schema, this.rowBuffer, { useDataPageV2: this.envelopeWriter!.useDataPageV2, bloomFilters: this.envelopeWriter!.bloomFilters});
 
-      await this.envelopeWriter.writeRowGroup(this.rowBuffer);
+      await this.envelopeWriter!.writeRowGroup(this.rowBuffer);
       this.rowBuffer = {};
     }
 
-    await this.envelopeWriter.writeBloomFilters();
-    await this.envelopeWriter.writeIndex();
-    await this.envelopeWriter.writeFooter(this.userMetadata);
-    await this.envelopeWriter.close();
+    await this.envelopeWriter!.writeBloomFilters();
+    await this.envelopeWriter!.writeIndex();
+    await this.envelopeWriter!.writeFooter(this.userMetadata);
+    await this.envelopeWriter!.close();
     this.envelopeWriter = null;
 
     if (callback) {
@@ -153,7 +154,7 @@ class ParquetWriter {
   /**
    * Add key<>value metadata to the file
    */
-  setMetadata(key, value) {
+  setMetadata(key: string, value: string) {
     this.userMetadata[key.toString()] = value.toString();
   }
 
@@ -163,7 +164,7 @@ class ParquetWriter {
    * of rows that are co-located on disk. A higher value is generally better for
    * read-time I/O performance at the tradeoff of write-time memory usage.
    */
-  setRowGroupSize(cnt) {
+  setRowGroupSize(cnt: number) {
     this.rowGroupSize = cnt;
   }
 
@@ -171,8 +172,8 @@ class ParquetWriter {
    * Set the parquet data page size. The data page size controls the maximum
    * number of column values that are written to disk as a consecutive array
    */
-  setPageSize(cnt) {
-    this.writer.setPageSize(cnt);
+  setPageSize(cnt: number) {
+    this.envelopeWriter!.setPageSize(cnt);
   }
 
 }
@@ -185,16 +186,27 @@ class ParquetWriter {
  */
 class ParquetEnvelopeWriter {
 
+  schema: ParquetSchema;
+  write: Function;
+  close: Function;
+  offset: number;
+  rowCount: number;
+  pageSize: number;
+  pageIndex: boolean;
+  useDataPageV2: boolean;
+  rowGroups: RowGroup[]
+  bloomFilters: Record<string, SplitBlockBloomFilter>
+
   /**
    * Create a new parquet envelope writer that writes to the specified stream
    */
-  static async openStream(schema: ParquetSchema, outputStream: WriteStream, opts?: string | streamOptions) {
+  static async openStream(schema: ParquetSchema, outputStream: WriteStream, opts: WriterOptions) {
     let writeFn = parquet_util.oswrite.bind(undefined, outputStream);
     let closeFn = parquet_util.osend.bind(undefined, outputStream);
     return new ParquetEnvelopeWriter(schema, writeFn, closeFn, 0, opts);
   }
 
-  constructor(schema, writeFn, closeFn, fileOffset, opts) {
+  constructor(schema: ParquetSchema, writeFn: Function, closeFn: Function, fileOffset: number, opts: WriterOptions) {
     this.schema = schema;
     this.write = writeFn;
     this.close = closeFn;
@@ -202,8 +214,8 @@ class ParquetEnvelopeWriter {
     this.rowCount = 0;
     this.rowGroups = [];
     this.pageSize =  opts.pageSize || PARQUET_DEFAULT_PAGE_SIZE;
-    this.useDataPageV2 = ("useDataPageV2" in opts) ? opts.useDataPageV2 : true;
-    this.pageIndex = opts.pageIndex;
+    this.useDataPageV2 = ("useDataPageV2" in opts) ? opts.useDataPageV2! : true;
+    this.pageIndex = opts.pageIndex!;
     this.bloomFilters = {};
 
     (opts.bloomFilters || []).forEach(bloomOption => {
@@ -211,7 +223,7 @@ class ParquetEnvelopeWriter {
     });
   }
 
-  writeSection(buf) {
+  writeSection(buf: Buffer) {
     this.offset += buf.length;
     return this.write(buf);
   }
@@ -227,7 +239,7 @@ class ParquetEnvelopeWriter {
    * Encode a parquet row group. The records object should be created using the
    * shredRecord method
    */
-  async writeRowGroup(records) {
+  async writeRowGroup(records: parquet_shredder.RecordBuffer) {
     let rgroup = await encodeRowGroup(
         this.schema,
         records,
@@ -238,12 +250,12 @@ class ParquetEnvelopeWriter {
           pageIndex: this.pageIndex
         });
 
-    this.rowCount += records.rowCount;
+    this.rowCount += records.rowCount!;
     this.rowGroups.push(rgroup.metadata);
     return this.writeSection(rgroup.body);
   }
 
-  writeBloomFilters(_rowGroups) {
+  writeBloomFilters(_rowGroups?: RowGroup[]) {
     let rowGroups = _rowGroups || this.rowGroups;
     rowGroups.forEach(group => {
       group.columns.forEach(column => {
@@ -263,7 +275,7 @@ class ParquetEnvelopeWriter {
   /**
    * Write the columnIndices and offsetIndices
    */
-  writeIndex(_rowGroups) {
+  writeIndex(_rowGroups?: RowGroup[]) {
     let rowGroups = _rowGroups || this.rowGroups;
     this.schema.fieldList.forEach( (c,i) => {
       rowGroups.forEach(group => {
@@ -292,7 +304,7 @@ class ParquetEnvelopeWriter {
   /**
    * Write the parquet file footer
    */
-  writeFooter(userMetadata, schema, rowCount, rowGroups) {
+  writeFooter(userMetadata: Record<string, string>, _schema?: ParquetSchema, _rowCount?: number, _rowGroups?: RowGroup[]) {
     if (!userMetadata) {
       userMetadata = {};
     }
@@ -309,7 +321,7 @@ class ParquetEnvelopeWriter {
    * Set the parquet data page size. The data page size controls the maximum
    * number of column values that are written to disk as a consecutive array
    */
-  setPageSize(cnt) {
+  setPageSize(cnt: number) {
     this.pageSize = cnt;
   }
 
@@ -320,11 +332,13 @@ class ParquetEnvelopeWriter {
  */
 class ParquetTransformer extends stream.Transform {
 
-  constructor(schema, opts = {}) {
+  writer: ParquetWriter;
+
+  constructor(schema: ParquetSchema, opts = {}) {
     super({ objectMode: true });
 
     let writeProxy = (function(t) {
-      return function(b) {
+      return function(b: unknown) {
         t.push(b);
       }
     })(this);
@@ -335,7 +349,7 @@ class ParquetTransformer extends stream.Transform {
         opts);
   }
 
-  _transform(row, encoding, callback) {
+  _transform(row: Record<string, unknown>, _encoding: string, callback: Function) {
     if (row) {
       this.writer.appendRow(row).then(
         data => callback(null, data),
@@ -350,7 +364,7 @@ class ParquetTransformer extends stream.Transform {
     }
   }
 
-  _flush(callback) {
+  _flush(callback: (foo: any, bar?: any) => any) {
     this.writer.close()
       .then(d => callback(null, d), callback);
   }
@@ -360,7 +374,7 @@ class ParquetTransformer extends stream.Transform {
 /**
  * Encode a consecutive array of data using one of the parquet encodings
  */
-function encodeValues(type, encoding, values, opts) {
+function encodeValues(type: string, encoding: ParquetCodec, values: number[], opts: any) {
   if (!(encoding in parquet_codec)) {
     throw 'invalid encoding: ' + encoding;
   }
@@ -368,7 +382,7 @@ function encodeValues(type, encoding, values, opts) {
   return parquet_codec[encoding].encodeValues(type, values, opts);
 }
 
-function encodeStatisticsValue(value, column) {
+function encodeStatisticsValue(value: any, column: ParquetField | Options) {
   if (value === undefined) {
     return Buffer.alloc(0);
   }
@@ -376,12 +390,12 @@ function encodeStatisticsValue(value, column) {
     value = parquet_types.toPrimitive(column.originalType,value);
   }
   if (column.primitiveType !== 'BYTE_ARRAY') {
-    value = encodeValues(column.primitiveType,'PLAIN',[value],column);
+    value = encodeValues(column.primitiveType!,'PLAIN',[value],column);
   }
   return value;
 }
 
-function encodeStatistics(statistics,column) {
+function encodeStatistics(statistics: parquet_thrift.Statistics,column: ParquetField | Options) {
   statistics = Object.assign({},statistics);
   statistics.min_value = statistics.min_value === undefined ? null : encodeStatisticsValue(statistics.min_value, column);
   statistics.max_value = statistics.max_value === undefined ? null : encodeStatisticsValue(statistics.max_value, column);
@@ -392,7 +406,7 @@ function encodeStatistics(statistics,column) {
   return new parquet_thrift.Statistics(statistics);
 }
 
-async function encodePages(schema, rowBuffer, opts) {
+async function encodePages(schema: ParquetSchema, rowBuffer: parquet_shredder.RecordBuffer, opts: writerOptions) {
   if (!rowBuffer.pageRowCount) {
     return;
   }
@@ -403,21 +417,21 @@ async function encodePages(schema, rowBuffer, opts) {
     }
 
     let page;
-    const values = rowBuffer.columnData[field.path];
+    const values = rowBuffer.columnData![field.path.join(',')];
 
     if (opts.bloomFilters && (field.name in opts.bloomFilters)) {
       const splitBlockBloomFilter = opts.bloomFilters[field.name];
-      values.values.forEach(v => splitBlockBloomFilter.insert(v));
+      values.values!.forEach(v => splitBlockBloomFilter.insert(v));
     }
 
-    let statistics;
+    let statistics: parquet_thrift.Statistics = {};
     if (field.statistics !== false) {
       statistics = {};
-      [...values.distinct_values].forEach( (v,i) => {
-        if (i === 0 || v > statistics.max_value) {
+      [...values.distinct_values!].forEach( (v,i) => {
+        if (i === 0 || v > statistics.max_value!) {
           statistics.max_value = v;
         }
-        if (i === 0 || v < statistics.min_value) {
+        if (i === 0 || v < statistics.min_value!) {
           statistics.min_value = v;
         }
       });
@@ -429,29 +443,29 @@ async function encodePages(schema, rowBuffer, opts) {
     if (opts.useDataPageV2) {
       page = await encodeDataPageV2(
         field,
-        values.count,
-        values.values,
-        values.rlevels,
-        values.dlevels,
-        statistics);
+        values.count!,
+        values.values!,
+        values.rlevels!,
+        values.dlevels!,
+        statistics!);
     } else {
       page = await encodeDataPage(
         field,
         values.values,
         values.rlevels,
         values.dlevels,
-        statistics);
+        statistics!);
     }
 
-    let pages = rowBuffer.pages[field.path];
+    let pages = rowBuffer.pages![field.path.join(',')];
     let lastPage = pages[pages.length-1];
-    let first_row_index = lastPage ? lastPage.first_row_index + lastPage.count : 0;
+    let first_row_index = lastPage ? lastPage.first_row_index + lastPage.count! : 0;
     pages.push({
       page,
       statistics,
       first_row_index,
-      distinct_values: values.distinct_values,
-      num_values: values.dlevels.length
+      distinct_values: values.distinct_values!,
+      num_values: values.dlevels!.length
     });
 
 
@@ -468,11 +482,11 @@ async function encodePages(schema, rowBuffer, opts) {
 /**
  * Encode a parquet data page
  */
-async function encodeDataPage(column, values, rlevels, dlevels, statistics) {
+async function encodeDataPage(column: ParquetField, values: number[], rlevels: number[], dlevels: number[], statistics: parquet_thrift.Statistics) {
   /* encode values */
   let valuesBuf = encodeValues(
-      column.primitiveType,
-      column.encoding,
+      column.primitiveType!,
+      column.encoding!,
       values, {
         typeLength: column.typeLength,
         bitWidth: column.typeLength
@@ -500,7 +514,7 @@ async function encodeDataPage(column, values, rlevels, dlevels, statistics) {
   /* build page header */
   let pageBody = Buffer.concat([rLevelsBuf, dLevelsBuf, valuesBuf]);
   pageBody = await parquet_compression.deflate(
-      column.compression,
+      column.compression!,
       pageBody);
 
   let pageHeader = new parquet_thrift.PageHeader();
@@ -513,7 +527,7 @@ async function encodeDataPage(column, values, rlevels, dlevels, statistics) {
     pageHeader.data_page_header.statistics = encodeStatistics(statistics, column);
   }
 
-  pageHeader.data_page_header.encoding = parquet_thrift.Encoding[column.encoding];
+  pageHeader.data_page_header.encoding = parquet_thrift.Encoding[column.encoding!];
   pageHeader.data_page_header.definition_level_encoding =
       parquet_thrift.Encoding[PARQUET_RDLVL_ENCODING];
   pageHeader.data_page_header.repetition_level_encoding =
@@ -526,18 +540,18 @@ async function encodeDataPage(column, values, rlevels, dlevels, statistics) {
 /**
  * Encode a parquet data page (v2)
  */
-async function encodeDataPageV2(column, rowCount, values, rlevels, dlevels, statistics) {
+async function encodeDataPageV2(column: ParquetField, rowCount: number, values: number[], rlevels: number[], dlevels: number[], statistics: parquet_thrift.Statistics) {
   /* encode values */
   let valuesBuf = encodeValues(
-      column.primitiveType,
-      column.encoding,
+      column.primitiveType!,
+      column.encoding!,
       values, {
         typeLength: column.typeLength,
         bitWidth: column.typeLength
       });
 
   let valuesBufCompressed = await parquet_compression.deflate(
-      column.compression,
+      column.compression!,
       valuesBuf);
 
   /* encode repetition and definition levels */
@@ -581,7 +595,7 @@ async function encodeDataPageV2(column, rowCount, values, rlevels, dlevels, stat
   pageHeader.compressed_page_size =
       rLevelsBuf.length + dLevelsBuf.length + valuesBufCompressed.length;
 
-  pageHeader.data_page_header_v2.encoding = parquet_thrift.Encoding[column.encoding];
+  pageHeader.data_page_header_v2.encoding = parquet_thrift.Encoding[column.encoding!];
   pageHeader.data_page_header_v2.definition_levels_byte_length = dLevelsBuf.length;
   pageHeader.data_page_header_v2.repetition_levels_byte_length = rLevelsBuf.length;
 
@@ -627,24 +641,24 @@ async function encodeColumnChunk(pages, opts) {
   offsetIndex.page_locations = [];
 
   /* prepare statistics */
-  let statistics = {};
+  let statistics: parquet_thrift.Statistics = {};
   let distinct_values = new Set();
-  statistics.null_count = 0;
-  statistics.distinct_count = 0;
+  statistics.null_count = new Int64(0);
+  statistics.distinct_count = new Int64(0);
 
   /* loop through pages and update indices and statistics */
   for (let i = 0; i < pages.length; i++) {
     let page = pages[i];
 
     if (opts.column.statistics !== false) {
-      if (page.statistics.max_value > statistics.max_value || i == 0) {
+      if (page.statistics.max_value > statistics.max_value! || i == 0) {
         statistics.max_value = page.statistics.max_value;
       }
-      if (page.statistics.min_value < statistics.min_value || i == 0) {
+      if (page.statistics.min_value < statistics.min_value! || i == 0) {
         statistics.min_value = page.statistics.min_value;
       }
       statistics.null_count += page.statistics.null_count;
-      page.distinct_values.forEach(value => distinct_values.add(value));
+      page.distinct_values.forEach((value: unknown) => distinct_values.add(value));
 
       columnIndex.max_values.push( encodeStatisticsValue(page.statistics.max_value, opts.column) );
       columnIndex.min_values.push( encodeStatisticsValue(page.statistics.min_value, opts.column) );
@@ -687,11 +701,11 @@ async function encodeColumnChunk(pages, opts) {
 /**
  * Encode a list of column values into a parquet row group
  */
-async function encodeRowGroup(schema, data, opts) {
-  let metadata = new parquet_thrift.RowGroup();
-  metadata.num_rows = data.rowCount;
+async function encodeRowGroup(schema: ParquetSchema, data: parquet_shredder.RecordBuffer, opts: WriterOptions) {
+  let metadata = new NewRowGroup();
+  metadata.num_rows = data.rowCount!;
   metadata.columns = [];
-  metadata.total_byte_size = 0;
+  metadata.total_byte_size = new Int64(0);
 
   let body = Buffer.alloc(0);
   for (let field of schema.fieldList) {
@@ -700,10 +714,10 @@ async function encodeRowGroup(schema, data, opts) {
     }
 
     let cchunkData = await encodeColumnChunk(
-      data.pages[field.path],
+      data.pages![field.path.join(',')],
       {
         column: field,
-        baseOffset: opts.baseOffset + body.length,
+        baseOffset: opts.baseOffset! + body.length,
         pageSize: opts.pageSize,
         encoding: field.encoding,
         rowCount: data.rowCount,
@@ -715,7 +729,7 @@ async function encodeRowGroup(schema, data, opts) {
     cchunk.file_offset = cchunkData.metadataOffset;
     cchunk.meta_data = cchunkData.metadata;
     metadata.columns.push(cchunk);
-    metadata.total_byte_size += cchunkData.body.length;
+    metadata.total_byte_size = new Int64(metadata.total_byte_size.valueOf() + (cchunkData.body.length));
 
     body = Buffer.concat([body, cchunkData.body]);
   }
@@ -726,8 +740,8 @@ async function encodeRowGroup(schema, data, opts) {
 /**
  * Encode a parquet file metadata footer
  */
-function encodeFooter(schema, rowCount, rowGroups, userMetadata) {
-  let metadata = new parquet_thrift.FileMetaData()
+function encodeFooter(schema: ParquetSchema, rowCount: Int64, rowGroups: RowGroup[], userMetadata: string[]) {
+  let metadata = new NewFileMetaData()
   metadata.version = PARQUET_VERSION;
   metadata.created_by = '@dsnp/parquetjs';
   metadata.num_rows = rowCount;
@@ -757,7 +771,7 @@ function encodeFooter(schema, rowCount, rowGroups, userMetadata) {
     if (field.isNested) {
       schemaElem.num_children = field.fieldCount;
     } else {
-      schemaElem.type = parquet_thrift.Type[field.primitiveType];
+      schemaElem.type = parquet_thrift.Type[field.primitiveType!];
     }
 
     if (field.originalType) {

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -6,7 +6,7 @@ import * as parquet_codec from './codec'
 import * as parquet_compression from './compression'
 import * as parquet_types from './types'
 import * as bloomFilterWriter from "./bloomFilterIO/bloomFilterWriter"
-import { WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, BloomFilterStreamOption, StreamOptions, filterCollection } from './types/types'
+import { WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, BloomFilterStreamOption, filterCollection } from './types/types'
 import { Options } from './codec/types'
 import Long from 'long'
 import { ParquetSchema } from './schema'
@@ -209,7 +209,7 @@ class ParquetEnvelopeWriter {
     return new ParquetEnvelopeWriter(schema, writeFn, closeFn, new Int64(0), opts);
   }
 
-  constructor(schema: ParquetSchema, writeFn: Function, closeFn: Function, fileOffset: Int64, opts: StreamOptions) {
+  constructor(schema: ParquetSchema, writeFn: Function, closeFn: Function, fileOffset: Int64, opts: WriterOptions) {
     this.schema = schema;
     this.write = writeFn;
     this.close = closeFn;
@@ -407,7 +407,7 @@ function encodeStatistics(statistics: parquet_thrift.Statistics,column: ParquetF
   return new parquet_thrift.Statistics(statistics);
 }
 
-async function encodePages(schema: ParquetSchema, rowBuffer: parquet_shredder.RecordBuffer, opts: writerOptions) {
+async function encodePages(schema: ParquetSchema, rowBuffer: parquet_shredder.RecordBuffer, opts: WriterOptions) {
   if (!rowBuffer.pageRowCount) {
     return;
   }

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -227,7 +227,7 @@ class ParquetEnvelopeWriter {
   }
 
   writeSection(buf: Buffer) {
-    this.offset.setValue(this.offset.toNumber() + buf.length)
+    this.offset.setValue(this.offset.valueOf() + buf.length)
     return this.write(buf);
   }
 
@@ -718,7 +718,7 @@ async function encodeRowGroup(schema: ParquetSchema, data: parquet_shredder.Reco
       data.pages![field.path.join(',')],
       {
         column: field,
-        baseOffset: opts.baseOffset! + body.length,
+        baseOffset: opts.baseOffset!.valueOf() + body.length,
         pageSize: opts.pageSize,
         encoding: field.encoding,
         rowCount: data.rowCount,

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -6,7 +6,7 @@ import * as parquet_codec from './codec'
 import * as parquet_compression from './compression'
 import * as parquet_types from './types'
 import * as bloomFilterWriter from "./bloomFilterIO/bloomFilterWriter"
-import { Offset, WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, BloomFilterStreamOption, StreamOptions, filterOptions, filterCollection } from './types/types'
+import { WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, BloomFilterStreamOption, StreamOptions, filterCollection } from './types/types'
 import { Options } from './codec/types'
 import Long from 'long'
 import { ParquetSchema } from './schema'
@@ -192,7 +192,7 @@ class ParquetEnvelopeWriter {
   schema: ParquetSchema
   write: Function;
   close: Function;
-  offset: number  // TODO: was number, not quite sure if Offset is correct
+  offset: Int64
   rowCount: Int64
   rowGroups: RowGroup[]
   pageSize: number;
@@ -227,7 +227,7 @@ class ParquetEnvelopeWriter {
   }
 
   writeSection(buf: Buffer) {
-    this.offset += buf.length;
+    this.offset.setValue(this.offset.toNumber() + buf.length)
     return this.write(buf);
   }
 

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -6,7 +6,7 @@ import * as parquet_codec from './codec'
 import * as parquet_compression from './compression'
 import * as parquet_types from './types'
 import * as bloomFilterWriter from "./bloomFilterIO/bloomFilterWriter"
-import { Offset, WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, BloomFilterStreamOption, StreamOptions, filterOptions } from './types/types'
+import { Offset, WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, BloomFilterStreamOption, StreamOptions, filterOptions, filterCollection } from './types/types'
 import { Options } from './codec/types'
 import Long from 'long'
 import { ParquetSchema } from './schema'

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -127,7 +127,7 @@ class ParquetWriter {
    * method twice on the same object or add any rows after the close() method has
    * been called
    */
-  async close(callback: Function) {
+  async close(callback?: Function) {
     if (this.closed) {
       throw 'writer was closed';
     }

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -6,7 +6,7 @@ import * as parquet_codec from './codec'
 import * as parquet_compression from './compression'
 import * as parquet_types from './types'
 import * as bloomFilterWriter from "./bloomFilterIO/bloomFilterWriter"
-import { WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, ColumnnMetaDataExt, BloomFilterStreamOption, filterCollection, Page } from './types/types'
+import { WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, ColumnnMetaDataExt, Page } from './types/types'
 import { Options } from './codec/types'
 import Long from 'long'
 import { ParquetSchema } from './schema'
@@ -106,7 +106,7 @@ class ParquetWriter {
 
     parquet_shredder.shredRecord(this.schema, row, this.rowBuffer);
 
-    const options: WriterOptions = {
+    const options = {
       useDataPageV2: this.envelopeWriter.useDataPageV2,
       bloomFilters: this.envelopeWriter.bloomFilters
     };
@@ -134,13 +134,13 @@ class ParquetWriter {
 
     this.closed = true;
 
-  if (this.envelopeWriter) {
-    if (this.rowBuffer.rowCount! > 0 || this.rowBuffer.rowCount! >= this.rowGroupSize) {
-      await encodePages(this.schema, this.rowBuffer, { useDataPageV2: this.envelopeWriter.useDataPageV2, bloomFilters: this.envelopeWriter.bloomFilters});
+    if (this.envelopeWriter) {
+      if (this.rowBuffer.rowCount! > 0 || this.rowBuffer.rowCount! >= this.rowGroupSize) {
+        await encodePages(this.schema, this.rowBuffer, { useDataPageV2: this.envelopeWriter.useDataPageV2, bloomFilters: this.envelopeWriter.bloomFilters});
 
-      await this.envelopeWriter.writeRowGroup(this.rowBuffer);
-      this.rowBuffer = {};
-    }
+        await this.envelopeWriter.writeRowGroup(this.rowBuffer);
+        this.rowBuffer = {};
+      }
 
 
       await this.envelopeWriter.writeBloomFilters();
@@ -407,7 +407,7 @@ function encodeStatistics(statistics: parquet_thrift.Statistics,column: ParquetF
   return new parquet_thrift.Statistics(statistics);
 }
 
-async function encodePages(schema: ParquetSchema, rowBuffer: parquet_shredder.RecordBuffer, opts: WriterOptions) {
+async function encodePages(schema: ParquetSchema, rowBuffer: parquet_shredder.RecordBuffer, opts: {bloomFilters: Record<string,SplitBlockBloomFilter>, useDataPageV2: boolean}) {// generic
   if (!rowBuffer.pageRowCount) {
     return;
   }

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -665,7 +665,7 @@ async function encodeColumnChunk(pages: Page[], opts: {column: ParquetField, bas
     }
 
     let pageLocation = new parquet_thrift.PageLocation();
-    pageLocation.offset.setValue(offset);
+    pageLocation.offset = new Int64(offset);
     offset += page.page.length;
     pageLocation.compressed_page_size = page.page.length;
     pageLocation.first_row_index = new Int64(page.first_row_index);

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -106,7 +106,7 @@ class ParquetWriter {
 
     parquet_shredder.shredRecord(this.schema, row, this.rowBuffer);
 
-    const options = {
+    const options: WriterOptions = {
       useDataPageV2: this.envelopeWriter.useDataPageV2,
       bloomFilters: this.envelopeWriter.bloomFilters
     };
@@ -346,7 +346,7 @@ class ParquetTransformer extends stream.Transform {
 
     this.writer = new ParquetWriter(
         schema,
-        new ParquetEnvelopeWriter(schema, writeProxy, function() {}, 0, opts),
+        new ParquetEnvelopeWriter(schema, writeProxy, function() {}, new Int64(0), opts),
         opts);
   }
 

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -8,7 +8,6 @@ import * as parquet_types from './types'
 import * as bloomFilterWriter from "./bloomFilterIO/bloomFilterWriter"
 import { WriterOptions, ParquetCodec, ParquetField, ColumnMetaDataExt, RowGroupExt, Page } from './types/types'
 import { Options } from './codec/types'
-import Long from 'long'
 import { ParquetSchema } from './schema'
 import { WriteStream } from 'fs'
 import Int64 from 'node-int64'

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -6,7 +6,7 @@ import * as parquet_codec from './codec'
 import * as parquet_compression from './compression'
 import * as parquet_types from './types'
 import * as bloomFilterWriter from "./bloomFilterIO/bloomFilterWriter"
-import { WriterOptions, RowGroup, NewFileMetaData, NewRowGroup, ParquetCodec, ParquetField, ColumnnMetaDataExt, Page } from './types/types'
+import { WriterOptions, ParquetCodec, ParquetField, ColumnMetaDataExt, RowGroupExt, Page } from './types/types'
 import { Options } from './codec/types'
 import Long from 'long'
 import { ParquetSchema } from './schema'
@@ -194,7 +194,7 @@ class ParquetEnvelopeWriter {
   close: Function;
   offset: Int64
   rowCount: Int64
-  rowGroups: RowGroup[]
+  rowGroups: RowGroupExt[]
   pageSize: number;
   useDataPageV2: boolean;
   pageIndex: boolean;
@@ -703,8 +703,8 @@ async function encodeColumnChunk(pages: Page[], opts: {column: ParquetField, bas
  * Encode a list of column values into a parquet row group
  */
 async function encodeRowGroup(schema: ParquetSchema, data: parquet_shredder.RecordBuffer, opts: WriterOptions) {
-  let metadata = new NewRowGroup();
-  metadata.num_rows = data.rowCount!;
+  let metadata: RowGroupExt = new parquet_thrift .RowGroup();
+  metadata.num_rows = new Int64(data.rowCount!);
   metadata.columns = [];
   metadata.total_byte_size = new Int64(0);
 
@@ -741,8 +741,8 @@ async function encodeRowGroup(schema: ParquetSchema, data: parquet_shredder.Reco
 /**
  * Encode a parquet file metadata footer
  */
-function encodeFooter(schema: ParquetSchema, rowCount: Int64, rowGroups: RowGroup[], userMetadata: Record<string, string>) {
-  let metadata = new NewFileMetaData()
+function encodeFooter(schema: ParquetSchema, rowCount: Int64, rowGroups: RowGroupExt[], userMetadata: Record<string, string>) {
+  let metadata = new parquet_thrift.FileMetaData()
   metadata.version = PARQUET_VERSION;
   metadata.created_by = '@dsnp/parquetjs';
   metadata.num_rows = rowCount;

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -437,8 +437,8 @@ async function encodePages(schema: ParquetSchema, rowBuffer: parquet_shredder.Re
         }
       });
 
-      statistics.null_count = values.dlevels.length - values.values.length;
-      statistics.distinct_count = values.distinct_values.size;
+      statistics.null_count = new Int64(values.dlevels!.length - values.values!.length);
+      statistics.distinct_count = new Int64(values.distinct_values!.size);
     }
 
     if (opts.useDataPageV2) {

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -355,7 +355,7 @@ class ParquetTransformer extends stream.Transform {
         data => callback(null, data),
         err => {
           const fullErr = new Error(`Error transforming to parquet: ${err.toString()} row:${row}`);
-          fullErr.cause = err;
+          fullErr.message = err;
           callback(fullErr);
         }
       );

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -192,7 +192,7 @@ class ParquetEnvelopeWriter {
   schema: ParquetSchema
   write: Function;
   close: Function;
-  offset: Offset  // TODO: was number, not quite sure if Offset is correct
+  offset: number  // TODO: was number, not quite sure if Offset is correct
   rowCount: Int64
   rowGroups: RowGroup[]
   pageSize: number;
@@ -206,10 +206,10 @@ class ParquetEnvelopeWriter {
   static async openStream(schema: ParquetSchema, outputStream: WriteStream, opts: WriterOptions) {
     let writeFn = parquet_util.oswrite.bind(undefined, outputStream);
     let closeFn = parquet_util.osend.bind(undefined, outputStream);
-    return new ParquetEnvelopeWriter(schema, writeFn, closeFn, new Int64(0), opts);
+    return new ParquetEnvelopeWriter(schema, writeFn, closeFn, 0, opts);
   }
 
-  constructor(schema: ParquetSchema, writeFn: Function, closeFn: Function, fileOffset: Offset, opts: StreamOptions) {
+  constructor(schema: ParquetSchema, writeFn: Function, closeFn: Function, fileOffset: number, opts: StreamOptions) {
     this.schema = schema;
     this.write = writeFn;
     this.close = closeFn;
@@ -227,7 +227,7 @@ class ParquetEnvelopeWriter {
   }
 
   writeSection(buf: Buffer) {
-    this.offset.offset += buf.length;
+    this.offset += buf.length;
     return this.write(buf);
   }
 

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -716,8 +716,8 @@ async function encodeRowGroup(schema: ParquetSchema, data: parquet_shredder.Reco
         baseOffset: opts.baseOffset!.valueOf() + body.length,
         pageSize: opts.pageSize || 0,
         rowCount: data.rowCount || 0,
-        useDataPageV2: !!opts.useDataPageV2,
-        pageIndex: !!opts.pageIndex
+        useDataPageV2: opts.useDataPageV2 ?? true,
+        pageIndex: opts.pageIndex ?? true
       });
 
     let cchunk = new parquet_thrift.ColumnChunk();

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -253,7 +253,7 @@ class ParquetEnvelopeWriter {
           pageIndex: this.pageIndex
         });
 
-    this.rowCount += records.rowCount!;
+    this.rowCount.setValue(this.rowCount.valueOf() + records.rowCount!);
     this.rowGroups.push(rgroup.metadata);
     return this.writeSection(rgroup.body);
   }
@@ -356,7 +356,7 @@ class ParquetTransformer extends stream.Transform {
         data => callback(null, data),
         err => {
           const fullErr = new Error(`Error transforming to parquet: ${err.toString()} row:${row}`);
-          fullErr.origErr = err;
+          fullErr.cause = err;
           callback(fullErr);
         }
       );
@@ -628,8 +628,8 @@ async function encodeColumnChunk(pages, opts) {
   metadata.num_values = num_values;
   metadata.data_page_offset = opts.baseOffset;
   metadata.encodings = [];
-  metadata.total_uncompressed_size = pagesBuf.length;
-  metadata.total_compressed_size = pagesBuf.length;
+  metadata.total_uncompressed_size = new Int64(pagesBuf.length);
+  metadata.total_compressed_size = new Int64(pagesBuf.length);
 
   metadata.type = parquet_thrift.Type[opts.column.primitiveType];
   metadata.codec = await parquet_thrift.CompressionCodec[opts.column.compression];

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -285,7 +285,7 @@ export class ParquetEnvelopeWriter {
         if (column.meta_data?.columnIndex) {
           let columnBody = parquet_util.serializeThrift(column.meta_data.columnIndex);
           delete column.meta_data.columnIndex;
-          column.column_index_offset = this.offset;
+          column.column_index_offset = parquet_util.cloneInteger(this.offset);
           column.column_index_length = columnBody.length;
           this.writeSection(columnBody);
         }
@@ -293,7 +293,7 @@ export class ParquetEnvelopeWriter {
         if (column.meta_data?.offsetIndex) {
           let offsetBody = parquet_util.serializeThrift(column.meta_data.offsetIndex);
           delete column.meta_data.offsetIndex;
-          column.offset_index_offset = this.offset;
+          column.offset_index_offset = parquet_util.cloneInteger(this.offset);
           column.offset_index_length = offsetBody.length;
           this.writeSection(offsetBody);
         }

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -685,12 +685,8 @@ async function encodeColumnChunk(pages: Page[], opts: {column: ParquetField, bas
   }
 
   /* list encodings */
-  let encodingsSet = {};
-  encodingsSet[PARQUET_RDLVL_ENCODING] = true;
-  encodingsSet[opts.column.encoding] = true;
-  for (let k in encodingsSet) {
-    metadata.encodings.push(parquet_thrift.Encoding[k]);
-  }
+  metadata.encodings.push(parquet_thrift.Encoding[PARQUET_RDLVL_ENCODING]);
+  metadata.encodings.push(parquet_thrift.Encoding[opts.column.encoding!]);
 
   /* concat metadata header and data pages */
   let metadataOffset = opts.baseOffset + pagesBuf.length;

--- a/test/bloomFilterReader.test.ts
+++ b/test/bloomFilterReader.test.ts
@@ -1,25 +1,25 @@
 import {expect} from "chai"
+import { Int64 } from "thrift";
 import { parseBloomFilterOffsets } from '../lib/bloomFilterIO/bloomFilterReader';
-import {ColumnChunkData, ColumnData, ColumnMetaData, Offset} from "../lib/types/types.js";
+import {ColumnChunkData, ColumnChunkExt, ColumnMetaDataExt} from "../lib/types/types.js";
 
-const emptyOffset= ():Offset => {
-  return { buffer: Buffer.from(""), offset: 0 }
-}
-const emptyMetaData = (): ColumnMetaData => {
+const emptyOffset = () => new Int64(Buffer.from(""), 0);
+
+const emptyMetaData = (): ColumnMetaDataExt => {
   return {
     type: 0,
     encodings: [],
     path_in_schema: [],
     codec: 0,
-    num_values: 0,
-    total_compressed_size: 0,
-    total_uncompressed_size: 0,
-    key_value_metadata: {},
+    num_values: new Int64(0),
+    total_compressed_size: new Int64(0),
+    total_uncompressed_size: new Int64(0),
+    key_value_metadata: [],
     data_page_offset: emptyOffset(),
     index_page_offset: emptyOffset(),
     dictionary_page_offset: emptyOffset(),
     statistics: {},
-    encoding_stats: {},
+    encoding_stats: [],
     bloom_filter_offset: emptyOffset()
   }
 }
@@ -30,14 +30,12 @@ describe("bloomFilterReader", () => {
 
 
     beforeEach(() => {
-      const metaData: ColumnMetaData = emptyMetaData()
+      const metaData: ColumnMetaDataExt = emptyMetaData()
         metaData.path_in_schema = ["name"]
-        metaData.bloom_filter_offset = {
-          buffer: Buffer.from("000000000874", "hex"),
-          offset: 0,
-        }
+        metaData.bloom_filter_offset = new Int64(
+          Buffer.from("000000000874", "hex"), 0)
 
-      const columnData: ColumnData = {
+      const columnData: ColumnChunkExt = {
         meta_data: metaData,
         file_offset: emptyOffset(),
         file_path: ''

--- a/test/bloomFilterReader.test.ts
+++ b/test/bloomFilterReader.test.ts
@@ -32,8 +32,7 @@ describe("bloomFilterReader", () => {
     beforeEach(() => {
       const metaData: ColumnMetaDataExt = emptyMetaData()
         metaData.path_in_schema = ["name"]
-        metaData.bloom_filter_offset = new Int64(
-          Buffer.from("000000000874", "hex"), 0)
+        metaData.bloom_filter_offset = new Int64(Buffer.from("000000000874", "hex"), 0)
 
       const columnData: ColumnChunkExt = {
         meta_data: metaData,

--- a/test/metadata-cache.js
+++ b/test/metadata-cache.js
@@ -23,7 +23,7 @@ describe('metadata-cache', function() {
         } catch(e) {}
       }
     }
-    const metaDataTxt = reader.exportMetadata();
+    const metaDataTxt = await reader.exportMetadata();
     metadata = JSON.parse(metaDataTxt);
   });
 


### PR DESCRIPTION
No JS files remaining in Parquet
=======
Adding types for writer/reader
========

#29 
with @wilwade @enddynayn 

Change summary:
---------------
* Removed duplicates of parquet types, and instead extended the interfaces
* Removed types that could use the framework (replace 'Offset' type with Int64)
* Added explicit type for passing optional arguments (ex: WriterOptions)
* Add multiple non-null assertions and optional chaining 

Steps to Verify:
----------------
1. npm run build
2. npm run test
