### PR TITLE
Better handling of millis and micros

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -461,18 +461,23 @@ function toPrimitive_TIMESTAMP_MICROS(value: Date | string | number | bigint) {
   }
 
   /* convert from integer */
-  {
+  try {
+    // Will throw if NaN
     const v = BigInt(value);
-    if (v < 0n /*|| isNaN(v)*/) {
-      throw 'invalid value for TIMESTAMP_MICROS: ' + value;
+    if (v < 0n) {
+      throw 'Cannot be less than zero';
     }
 
     return v;
+  } catch (e) {
+    throw 'invalid value for TIMESTAMP_MICROS: ' + value;
   }
 }
 
 function fromPrimitive_TIMESTAMP_MICROS(value: number | bigint) {
-  return typeof value === 'bigint' ? new Date(Number(value / 1000n)): new Date(value / 1000);
+    if (value === undefined) return new Date(NaN);
+    if (typeof value === 'bigint') return new Date(Number(value / 1000n));
+    return new Date(value / 1000);
   }
 
 function toPrimitive_INTERVAL(value: INTERVAL) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -386,7 +386,8 @@ function toPrimitive_TIME_MILLIS(value: string | number) {
   if (typeof value === `string`) {
     v = parseInt(value, 10);
   }
-  if (v < 0 || v > 0xffffffffffffffff || typeof v !== 'number') {
+  // Year 2255 bug. Should eventually switch to bigint
+  if (v < 0 || v > (Number.MAX_SAFE_INTEGER - 1) || typeof v !== 'number') {
     throw 'invalid value for TIME_MILLIS: ' + value;
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -476,7 +476,6 @@ function toPrimitive_TIMESTAMP_MICROS(value: Date | string | number | bigint) {
 }
 
 function fromPrimitive_TIMESTAMP_MICROS(value: number | bigint) {
-    if (value === undefined) return new Date(NaN);
     if (typeof value === 'bigint') return new Date(Number(value / 1000n));
     return new Date(value / 1000);
   }


### PR DESCRIPTION
Problem
=======

TIMESTAMP_MICROS would not always handle bigint correctly.

From: https://github.com/ZJONSSON/parquetjs/issues/58

Solution
========
Cleanup the code some

Change summary:
---------------
* Fix up TIMESTAMP_MICROS functions
* Fix toPrimitive_TIME_MILLIS to better handle overflows.