### PR TITLE
Feature - collect and report multiple field errors

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -81,6 +81,7 @@ function buildFields(schema: SchemaDefinition, rLevelParentMax?: number, dLevelP
   }
 
   let fieldList: Record<string, ParquetField> = {};
+  let fieldErrors: Array<string> = [];
   for (let name in schema) {
     const opts = schema[name];
 
@@ -129,9 +130,15 @@ function buildFields(schema: SchemaDefinition, rLevelParentMax?: number, dLevelP
       continue;
     }
 
+    let nameWithPath = (`${name}` || 'missing name')
+    if (path && path.length > 0) {
+      nameWithPath = `${path}.${nameWithPath}`
+    }
+
     const typeDef = opts.type ? parquet_types.PARQUET_LOGICAL_TYPES[opts.type] : undefined;
     if (!typeDef) {
-      throw 'invalid parquet type: ' + (opts.type || "missing type");
+      fieldErrors.push(`invalid parquet type: ${(opts.type || "missing type")}, for Column: ${nameWithPath}`);
+      continue;
     }
 
     /* field encoding */
@@ -165,6 +172,10 @@ function buildFields(schema: SchemaDefinition, rLevelParentMax?: number, dLevelP
       rLevelMax: rLevelMax,
       dLevelMax: dLevelMax
     };
+  }
+
+  if (fieldErrors.length > 0) {
+    throw fieldErrors.reduce((accumulator, currentVal) => accumulator + '\n' + currentVal);
   }
 
   return fieldList;

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -137,7 +137,7 @@ function buildFields(schema: SchemaDefinition, rLevelParentMax?: number, dLevelP
 
     const typeDef = opts.type ? parquet_types.PARQUET_LOGICAL_TYPES[opts.type] : undefined;
     if (!typeDef) {
-      fieldErrors.push(`invalid parquet type: ${(opts.type || "missing type")}, for Column: ${nameWithPath}`);
+      fieldErrors.push(`Invalid parquet type: ${(opts.type || "missing type")}, for Column: ${nameWithPath}`);
       continue;
     }
 
@@ -147,7 +147,7 @@ function buildFields(schema: SchemaDefinition, rLevelParentMax?: number, dLevelP
     }
 
     if (!(opts.encoding in parquet_codec)) {
-      fieldErrors.push(`unsupported parquet encoding: ${opts.encoding}, for Column: ${nameWithPath}`);
+      fieldErrors.push(`Unsupported parquet encoding: ${opts.encoding}, for Column: ${nameWithPath}`);
     }
 
     if (!opts.compression) {
@@ -155,7 +155,7 @@ function buildFields(schema: SchemaDefinition, rLevelParentMax?: number, dLevelP
     }
 
     if (!(opts.compression in parquet_compression.PARQUET_COMPRESSION_METHODS)) {
-      fieldErrors.push(`unsupported compression method: ${opts.compression}, for Column: ${nameWithPath}`);
+      fieldErrors.push(`Unsupported compression method: ${opts.compression}, for Column: ${nameWithPath}`);
     }
 
     /* add to schema */

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -147,7 +147,7 @@ function buildFields(schema: SchemaDefinition, rLevelParentMax?: number, dLevelP
     }
 
     if (!(opts.encoding in parquet_codec)) {
-      throw 'unsupported parquet encoding: ' + opts.encoding;
+      fieldErrors.push(`unsupported parquet encoding: ${opts.encoding}, for Column: ${nameWithPath}`);
     }
 
     if (!opts.compression) {
@@ -155,7 +155,7 @@ function buildFields(schema: SchemaDefinition, rLevelParentMax?: number, dLevelP
     }
 
     if (!(opts.compression in parquet_compression.PARQUET_COMPRESSION_METHODS)) {
-      throw 'unsupported compression method: ' + opts.compression;
+      fieldErrors.push(`unsupported compression method: ${opts.compression}, for Column: ${nameWithPath}`);
     }
 
     /* add to schema */

--- a/test/schema.js
+++ b/test/schema.js
@@ -484,6 +484,15 @@ describe('ParquetSchema', function() {
     }, 'Invalid parquet type: UNKNOWN, for Column: quantity\nInvalid parquet type: UNKNOWN, for Column: value');
   });
 
+  it('should indicate each column which has an invalid type when one is correct in a simple flat schema', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        quantity: {type: 'INT32'},
+        value: {type: 'UNKNOWN'},
+      })
+    }, 'Invalid parquet type: UNKNOWN, for Column: value');
+  });
+
   it('should indicate each column which has an invalid type in a nested schema', function() {
     assert.throws(() => {
       new parquet.ParquetSchema({

--- a/test/schema.js
+++ b/test/schema.js
@@ -472,7 +472,7 @@ describe('ParquetSchema', function() {
       new parquet.ParquetSchema({
         quantity: {type: 'UNKNOWN'},
       })
-    }, 'invalid parquet type: UNKNOWN, for Column: quantity');
+    }, 'Invalid parquet type: UNKNOWN, for Column: quantity');
   });
 
   it('should indicate each column which has an invalid type in a simple flat schema', function() {
@@ -481,7 +481,7 @@ describe('ParquetSchema', function() {
         quantity: {type: 'UNKNOWN'},
         value: {type: 'UNKNOWN'},
       })
-    }, 'invalid parquet type: UNKNOWN, for Column: quantity\ninvalid parquet type: UNKNOWN, for Column: value');
+    }, 'Invalid parquet type: UNKNOWN, for Column: quantity\nInvalid parquet type: UNKNOWN, for Column: value');
   });
 
   it('should indicate each column which has an invalid type in a nested schema', function() {
@@ -496,7 +496,7 @@ describe('ParquetSchema', function() {
         },
         price: { type: 'UNKNOWN' },
       })
-    }, 'invalid parquet type: UNKNOWN, for Column: stock.quantity\ninvalid parquet type: UNKNOWN, for Column: stock.warehouse');
+    }, 'Invalid parquet type: UNKNOWN, for Column: stock.quantity\nInvalid parquet type: UNKNOWN, for Column: stock.warehouse');
   });
 
   it('should indicate which column had an invalid type in a simple flat schema - encoding', function() {

--- a/test/schema.js
+++ b/test/schema.js
@@ -467,4 +467,44 @@ describe('ParquetSchema', function() {
     }
   });
 
+  it('should indicate which column had an invalid type in a simple flat schema', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        quantity: {type: 'UNKNOWN'},
+      })
+    }, 'invalid parquet type: UNKNOWN, for Column: quantity');
+  });
+
+  it('should indicate each column which has an invalid type in a simple flat schema', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        quantity: {type: 'UNKNOWN'},
+        value: {type: 'UNKNOWN'},
+      })
+    }, 'invalid parquet type: UNKNOWN, for Column: quantity\ninvalid parquet type: UNKNOWN, for Column: value');
+  });
+
+  it('should indicate each column which has an invalid type in a nested schema', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        name: { type: 'UTF8' },
+        stock: {
+          fields: {
+            quantity: { type: 'UNKNOWN' },
+            warehouse: { type: 'UNKNOWN' },
+          }
+        },
+        price: { type: 'UNKNOWN' },
+      })
+    }, 'invalid parquet type: UNKNOWN, for Column: stock.quantity\ninvalid parquet type: UNKNOWN, for Column: stock.warehouse');
+  });
+
+  it('should indicate which column had an invalid type in a simple flat schema - encoding', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        quantity: {type: 'UNKNOWN', compression: 'PLAIN'},
+      })
+    }, 'invalid parquet type: UNKNOWN, for Column: quantity');
+  });
+
 });

--- a/test/schema.js
+++ b/test/schema.js
@@ -508,12 +508,13 @@ describe('ParquetSchema', function() {
     }, 'Invalid parquet type: UNKNOWN, for Column: stock.quantity\nInvalid parquet type: UNKNOWN, for Column: stock.warehouse');
   });
 
-  it('should indicate which column had an invalid type in a simple flat schema - encoding', function() {
+  it('should indicate which column had an invalid encoding in a simple flat schema', function() {
     assert.throws(() => {
       new parquet.ParquetSchema({
-        quantity: {type: 'UNKNOWN', compression: 'PLAIN'},
+        quantity: {type: 'INT32', encoding: 'UNKNOWN'},
       })
-    }, 'invalid parquet type: UNKNOWN, for Column: quantity');
+    }, 'Unsupported parquet encoding: UNKNOWN, for Column: quantity');
+  });
   });
 
 });

--- a/test/schema.js
+++ b/test/schema.js
@@ -515,6 +515,13 @@ describe('ParquetSchema', function() {
       })
     }, 'Unsupported parquet encoding: UNKNOWN, for Column: quantity');
   });
+
+  it('should indicate which column had an invalid compression type in a simple flat schema', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        quantity: {type: 'INT32', compression: 'UNKNOWN'},
+      })
+    }, 'Unsupported compression method: UNKNOWN, for Column: quantity');
   });
 
 });


### PR DESCRIPTION
Problem
=======
This PR is intended to implement 2 enhancements to schema error reporting.
* When a parquet schema includes an invalid type, encoding or compression the current error does not indicate which column has the the problem
* When a parquet schema has multiple issues, the code currently fails on the first, making multiple errors quite cumbersome

Solution
========
Modified the schema.ts and added tests to:
* Change error messages from the original `invalid parquet type: UNKNOWN` to `invalid parquet type: UNKNOWN, for Column: quantity`
* Keep track of schema errors as we loop through each column in the schema, and at the end, if there are any errors report them all as below:
`invalid parquet type: UNKNOWN, for Column: quantity`
`invalid parquet type: UNKNOWN, for Column: value`

Change summary:
---------------
* adding tests and code to ensure multiple field errors are logged, as well as indicating which column had the error
* also adding code to handle multiple encoding and compression schema issues

Steps to Verify:
----------------
1. Download this [parquet file](https://usaz02prismdevmlaas01.blob.core.windows.net/ml-job-config/dataSets/multiple-unsupported-columns.parquet?sv=2020-10-02&st=2023-01-09T15%3A28%3A09Z&se=2025-01-10T15%3A28%3A00Z&sr=b&sp=r&sig=GS0Skk93DCn5CnC64DbnIH2U7JhzHM2nnhq1U%2B2HwPs%3D)
2. attempt to open this parquet with this library `const reader = await parquet.ParquetReader.openFile(<path to parquet file>)`
3. You should receive errors for more than one column, which also includes the column name for each error
