### PR TITLE
feat(compression): add ZSTD compression support for both Node.js and the browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@oneidentity/zstd-js": "^1.0.3",
         "@types/long": "^4.0.2",
         "@types/node-int64": "^0.4.29",
         "@types/thrift": "^0.10.11",
@@ -103,6 +104,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/@oneidentity/zstd-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@oneidentity/zstd-js/-/zstd-js-1.0.3.tgz",
+      "integrity": "sha512-Jm6sawqxLzBrjC4sg2BeXToa33yPzUmq20CKsehKY2++D/gHb/oSwVjNgT+RH4vys+r8FynrgcNzGwhZWMLzfQ==",
+      "dependencies": {
+        "@types/emscripten": "^1.39.4"
+      }
+    },
     "node_modules/@open-draft/until": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
@@ -190,6 +199,11 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.39.6",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz",
+      "integrity": "sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg=="
     },
     "node_modules/@types/js-levenshtein": {
       "version": "1.1.1",
@@ -3801,6 +3815,14 @@
         "strict-event-emitter": "^0.2.0"
       }
     },
+    "@oneidentity/zstd-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@oneidentity/zstd-js/-/zstd-js-1.0.3.tgz",
+      "integrity": "sha512-Jm6sawqxLzBrjC4sg2BeXToa33yPzUmq20CKsehKY2++D/gHb/oSwVjNgT+RH4vys+r8FynrgcNzGwhZWMLzfQ==",
+      "requires": {
+        "@types/emscripten": "^1.39.4"
+      }
+    },
     "@open-draft/until": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
@@ -3887,6 +3909,11 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
+    },
+    "@types/emscripten": {
+      "version": "1.39.6",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz",
+      "integrity": "sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg=="
     },
     "@types/js-levenshtein": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "git://github.com/LibertyDSNP/parquetjs.git"
   },
   "dependencies": {
+    "@oneidentity/zstd-js": "^1.0.3",
     "@types/long": "^4.0.2",
     "@types/node-int64": "^0.4.29",
     "@types/thrift": "^0.10.11",

--- a/test/integration.js
+++ b/test/integration.js
@@ -483,6 +483,16 @@ describe('Parquet', function() {
       return await writeTestFile(opts).then(readTestFile);
     });
 
+    it('write a test file with ZSTD compression', function() {
+      const opts = { useDataPageV2: true, compression: 'ZSTD' };
+      return writeTestFile(opts);
+    });
+
+    it('write a test file with ZSTD compression and then read it back', function() {
+      const opts = { useDataPageV2: true, compression: 'ZSTD' };
+      return writeTestFile(opts).then(readTestFile);
+    });
+
     it('write a Uint8Array field and then read it back', async function() {
       const opts = { useDataPageV2: true, compression: 'UNCOMPRESSED' };
       const schema = new parquet.ParquetSchema({


### PR DESCRIPTION
Problem
=======

As described in the issue I opened here: https://github.com/LibertyDSNP/parquetjs/issues/77, the amount of compression algorithms that are described in the Parquet file format specification increased and now include the ZSTD method.
This compression algorithm is currently not supported by this package.

Solution
========

I quickly added ZSTD support by using an NPM module both compatible with the browser and Node.js called [@oneidentity/zstd-js](https://www.npmjs.com/package/@oneidentity/zstd-js).

This PR simply calls the compression and decompression methods of the underlying ZSTD library.

One point of interest is that the Node.js use-case requires some type conversions due to the accepted input types of the ZSTD library.