### PR TITLE
Decimal Writer Support

### DIFF
--- a/lib/codec/plain.ts
+++ b/lib/codec/plain.ts
@@ -86,15 +86,11 @@ function decodeValues_INT64(cursor: Cursor, count: number, opts: Options) {
 }
 
 function decodeValues_DECIMAL(cursor: Cursor, count: number, opts: Options) {
-  let {
-    scale,
-    precision
-  } = opts;
+  const precision = opts.precision;
+  // Default scale to 0 per spec
+  const scale = opts.scale || 0;
 
   const name = opts.name || undefined
-  if (!scale) {
-    throw `missing option: scale (required for DECIMAL) for column: ${name}`;
-  }
   if (!precision) {
     throw `missing option: precision (required for DECIMAL) for column: ${name}`;
   }

--- a/lib/codec/plain_dictionary.ts
+++ b/lib/codec/plain_dictionary.ts
@@ -2,7 +2,7 @@ import * as rle from './rle'
 import { Cursor, Options } from './types'
 
 export const decodeValues = function(type: string, cursor: Cursor, count: number, opts: Options) {
-  opts.bitWidth = cursor.buffer.slice(cursor.offset, cursor.offset+1).readInt8(0);
+  const bitWidth = cursor.buffer.slice(cursor.offset, cursor.offset+1).readInt8(0);
   cursor.offset += 1;
-  return rle.decodeValues(type, cursor, count, Object.assign({}, opts, {disableEnvelope: true}));
+  return rle.decodeValues(type, cursor, count, Object.assign({}, opts, { disableEnvelope: true, bitWidth }));
 };

--- a/lib/codec/rle.ts
+++ b/lib/codec/rle.ts
@@ -3,9 +3,9 @@
 // https://github.com/apache/parquet-format/blob/master/Encodings.md
 
 import varint from 'varint'
-import {Cursor, Options} from './types'
+import { Cursor } from './types'
 
-function encodeRunBitpacked(values: Array<number>, opts: Options) {
+function encodeRunBitpacked(values: Array<number>, opts: { bitWidth: number }) {
   for (let i = 0; i < values.length % 8; i++) {
     values.push(0);
   }
@@ -23,7 +23,7 @@ function encodeRunBitpacked(values: Array<number>, opts: Options) {
   ]);
 }
 
-function encodeRunRepeated(value: number, count: number, opts: Options) {
+function encodeRunRepeated(value: number, count: number, opts: { bitWidth: number }) {
   let buf = Buffer.alloc(Math.ceil(opts.bitWidth / 8));
   let remainingValue = value
 
@@ -48,7 +48,7 @@ function unknownToParsedInt(value: string | number) {
   }
 }
 
-export const encodeValues = function(type: string, values: Array<number>, opts: Options) {
+export const encodeValues = function(type: string, values: Array<number>, opts: { bitWidth: number, disableEnvelope?: boolean }) {
   if (!('bitWidth' in opts)) {
     throw 'bitWidth is required';
   }
@@ -108,7 +108,7 @@ export const encodeValues = function(type: string, values: Array<number>, opts: 
   return envelope;
 };
 
-function decodeRunBitpacked(cursor : Cursor, count: number, opts: Options) {
+function decodeRunBitpacked(cursor : Cursor, count: number, opts: { bitWidth: number }) {
   if (count % 8 !== 0) {
     throw 'must be a multiple of 8';
   }
@@ -124,7 +124,7 @@ function decodeRunBitpacked(cursor : Cursor, count: number, opts: Options) {
   return values;
 }
 
-function decodeRunRepeated(cursor: Cursor, count: number, opts: Options) {
+function decodeRunRepeated(cursor: Cursor, count: number, opts: { bitWidth: number }) {
   var bytesNeededForFixedBitWidth = Math.ceil(opts.bitWidth / 8);
   let value = 0;
 
@@ -139,7 +139,7 @@ function decodeRunRepeated(cursor: Cursor, count: number, opts: Options) {
   return new Array(count).fill(value);
 }
 
-export const decodeValues = function(_: string, cursor: Cursor, count: number, opts: Options) {
+export const decodeValues = function(_: string, cursor: Cursor, count: number, opts: { bitWidth: number, disableEnvelope?: boolean }) {
   if (!('bitWidth' in opts)) {
     throw 'bitWidth is required';
   }

--- a/lib/codec/types.ts
+++ b/lib/codec/types.ts
@@ -5,7 +5,7 @@ import { Statistics } from "../../gen-nodejs/parquet_types";
 export interface Options {
     typeLength: number,
     bitWidth: number,
-    disableEnvelope: boolean
+    disableEnvelope?: boolean
     primitiveType?: PrimitiveType;
     originalType?: OriginalType;
     encoding?: ParquetCodec;

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -1021,8 +1021,8 @@ async function decodeDataPageV2(cursor: Cursor, header: parquet_thrift.PageHeade
       valuesBufCursor,
       valueCountNonNull,
       {
-        typeLength: opts.column!.typeLength!,
-        bitWidth: opts.column!.typeLength!
+        bitWidth: opts.column!.typeLength!,
+        ...opts.column!
       });
 
   return {

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -22,9 +22,9 @@ const {
 const PARQUET_MAGIC = 'PAR1';
 
 /**
- * Parquet File Format Version
+ * Supported Parquet File Format Version for reading
  */
-const PARQUET_VERSION = 1;
+const PARQUET_VERSIONS = [1, 2];
 
 /**
  * Internal type used for repetition/definition levels
@@ -166,7 +166,7 @@ export class ParquetReader {
    */
   constructor(metadata: FileMetaDataExt, envelopeReader: ParquetEnvelopeReader, opts?: BufferReaderOptions) {
     opts = opts || {};
-    if (metadata.version != PARQUET_VERSION) {
+    if (!PARQUET_VERSIONS.includes(metadata.version)) {
       throw 'invalid parquet version';
     }
 

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -545,8 +545,8 @@ async function encodeDataPageV2(column: ParquetField, rowCount: number, values: 
       column.primitiveType!,
       column.encoding!,
       values, {
-        typeLength: column.typeLength,
-        bitWidth: column.typeLength
+        bitWidth: column.typeLength,
+        ...column,
       });
 
   let valuesBufCompressed = await parquet_compression.deflate(

--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -1,5 +1,5 @@
 import stream from 'stream'
-import parquet_thrift from '../gen-nodejs/parquet_types'
+import parquet_thrift, { ConvertedType } from '../gen-nodejs/parquet_types'
 import * as parquet_shredder from './shred'
 import * as parquet_util from './util'
 import * as parquet_codec from './codec'
@@ -487,8 +487,8 @@ async function encodeDataPage(column: ParquetField, values: number[], rlevels: n
       column.primitiveType!,
       column.encoding!,
       values, {
-        typeLength: column.typeLength,
-        bitWidth: column.typeLength
+        bitWidth: column.typeLength,
+        ...column
       });
 
   /* encode repetition and definition levels */
@@ -770,6 +770,14 @@ function encodeFooter(schema: ParquetSchema, rowCount: Int64, rowGroups: RowGrou
 
     if (field.originalType) {
       schemaElem.converted_type = parquet_thrift.ConvertedType[field.originalType];
+    }
+
+    // Support Decimal
+    switch(schemaElem.converted_type) {
+      case (ConvertedType.DECIMAL):
+        schemaElem.precision = field.precision;
+        schemaElem.scale = field.scale || 0;
+        break;
     }
 
     schemaElem.type_length = field.typeLength;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       "devDependencies": {
         "@types/bson": "^4.2.0",
         "@types/chai": "^4.3.5",
-        "@types/json-schema": "",
+        "@types/json-schema": "^7.0.11",
         "@types/mocha": "^10.0.1",
         "@types/node": "^16.18.32",
         "@types/sinon": "^10.0.15",

--- a/test/integration.js
+++ b/test/integration.js
@@ -578,24 +578,46 @@ describe('Parquet', function() {
   });
 
   describe('Decimal schema', function() {
+    const schema = new parquet.ParquetSchema({
+      zero_column: { type: 'DECIMAL', precision: 10, scale: 0 },
+      no_scale_column: { type: 'DECIMAL', precision: 10 },
+      scale_64_column: { type: 'DECIMAL', precision: 10, scale: 2 },
+      scale_32_column: { type: 'DECIMAL', precision: 8, scale: 2 },
+    });
 
-    it('write a test with decimals file and read it back', async function() {
-      const file = "decimal-test.parquet";
+    const rowData = {
+      zero_column: 1,
+      no_scale_column: 2,
+      scale_64_column: 3.345678901234567,
+      scale_32_column: 3.3,
+    };
+
+    it('write a test file with decimals in v1 data page and read it back', async function() {
+      const file = "decimal-test-v1.parquet";
       const opts = { useDataPageV2: false };
-      const schema = new parquet.ParquetSchema({
-        zero_column: { type: 'DECIMAL', precision: 10, scale: 0 },
-        no_scale_column: { type: 'DECIMAL', precision: 10 },
-        scale_64_column: { type: 'DECIMAL', precision: 10, scale: 2 },
-        scale_32_column: { type: 'DECIMAL', precision: 8, scale: 2 },
-      });
       const writer = await parquet.ParquetWriter.openFile(schema, file, opts);
 
-      await writer.appendRow({
+      await writer.appendRow(rowData);
+      await writer.close();
+
+      const reader = await parquet.ParquetReader.openFile(file);
+
+      const cursor = reader.getCursor();
+      const row = await cursor.next();
+      assert.deepEqual(row, {
         zero_column: 1,
         no_scale_column: 2,
-        scale_64_column: 3.345678901234567,
+        scale_64_column: 3.34, // Scale 2
         scale_32_column: 3.3,
-      });
+      })
+    });
+
+    it('write a test file with decimals in v2 data page and read it back', async function() {
+      const file = "decimal-test-v2.parquet";
+      const opts = { useDataPageV2: true };
+      const writer = await parquet.ParquetWriter.openFile(schema, file, opts);
+
+      await writer.appendRow(rowData);
       await writer.close();
 
       const reader = await parquet.ParquetReader.openFile(file);

--- a/test/schema.js
+++ b/test/schema.js
@@ -529,15 +529,23 @@ describe('ParquetSchema', function() {
       new parquet.ParquetSchema({
         test_decimal_col: {type: 'DECIMAL', scale: 4},
       })
-    }, 'invalid schema for type: DECIMAL, for Column: test_decimal_col, precision is required');
+    }, 'invalid schema for type: DECIMAL, for Column: test_decimal_col, precision is required and must be be greater than 0');
   });
 
-  it('should throw error given decimal with no scale', function() {
-    assert.throws(() => {
+  it('should NOT throw error given decimal with no scale', function() {
+    assert.doesNotThrow(() => {
       new parquet.ParquetSchema({
         test_decimal_col: {type: 'DECIMAL', precision: 4},
       })
-    }, 'invalid schema for type: DECIMAL, for Column: test_decimal_col, scale is required');
+    });
+  });
+
+  it('should throw error given decimal with negative precision', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        decimal_column: {type: 'DECIMAL', precision: -1, scale: 0},
+      })
+    }, 'invalid schema for type: DECIMAL, for Column: decimal_column, precision is required and must be be greater than 0');
   });
 
   it('should throw error given decimal with over 18 precision', function() {
@@ -545,7 +553,39 @@ describe('ParquetSchema', function() {
       new parquet.ParquetSchema({
         decimal_column: {type: 'DECIMAL', precision: 19, scale: 5},
       })
-    }, 'invalid precision for type: DECIMAL, for Column: decimal_column, can not handle precision over 18');
+    }, 'invalid schema for type: DECIMAL, for Column: decimal_column, can not handle precision over 18');
+  });
+
+  it('should throw error given decimal with a non-integer precision', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        decimal_column: {type: 'DECIMAL', precision: 6.1, scale: 5},
+      })
+    }, 'invalid schema for type: DECIMAL, for Column: decimal_column, precision must be an integer');
+  });
+
+  it('should throw error given decimal with a non-integer scale', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        decimal_column: {type: 'DECIMAL', precision: 6, scale: 5.1},
+      })
+    }, 'invalid schema for type: DECIMAL, for Column: decimal_column, scale must be an integer');
+  });
+
+  it('should throw error given decimal with negative scale', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        decimal_column: {type: 'DECIMAL', precision: 6, scale: -1},
+      })
+    }, 'invalid schema for type: DECIMAL, for Column: decimal_column, scale is required to be 0 or greater');
+  });
+
+  it('should throw error given decimal with scale > precision', function() {
+    assert.throws(() => {
+      new parquet.ParquetSchema({
+        decimal_column: {type: 'DECIMAL', precision: 5, scale: 6},
+      })
+    }, 'invalid schema or precision for type: DECIMAL, for Column: decimal_column, precision must be greater than or equal to scale');
   });
 
 });


### PR DESCRIPTION
Problem
=======
Need to support writing decimal types

Also closes: #87 

Solution
========

Add basic encoding support for decimals

Change summary:
---------------
* Added better decimal field errors
* Default scale to 0 per spec
* Cleanup types on RLE so it only asks for what is needed
* Support decimal encoding
* Add test for write / read of decimal

Steps to Verify:
----------------
1. Generate a schema with decimal field
2. Use it!