### PR TITLE
Update docs and add simple test for readme encoding examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,12 +329,12 @@ var schema = new parquet.ParquetSchema({
 The Parquet hybrid run length and bitpacking encoding allows to compress runs
 of numbers very efficiently. Note that the RLE encoding can only be used in
 combination with the `BOOLEAN`, `INT32` and `INT64` types. The RLE encoding
-requires an additional `bitWidth` parameter that contains the maximum number of
+requires an additional `typeLength` parameter that contains the maximum number of
 bits required to store the largest value of the field.
 
 ``` js
 var schema = new parquet.ParquetSchema({
-  age: { type: 'UINT_32', encoding: 'RLE', bitWidth: 7 },
+  age: { type: 'UINT_32', encoding: 'RLE', typeLength: 7 },
 });
 ```
 

--- a/test/readme-examples.test.ts
+++ b/test/readme-examples.test.ts
@@ -1,0 +1,21 @@
+import { expect } from "chai";
+
+import { ParquetSchema } from '../parquet';
+
+describe("Readme Encoding Examples", function () {
+  it("PLAIN should work", function () {
+    const ps = new ParquetSchema({
+      name: { type: 'UTF8', encoding: 'PLAIN' },
+    });
+    expect(ps).to.be.a("object");
+    expect(ps.schema.name.encoding).to.eq("PLAIN");
+  });
+
+  it("RLE should work", function () {
+    const ps = new ParquetSchema({
+      age: { type: 'UINT_32', encoding: 'RLE', typeLength: 7 },
+    });
+    expect(ps).to.be.a("object");
+    expect(ps.schema.age.typeLength).to.eq(7);
+  });
+});


### PR DESCRIPTION
Problem
=======
Docs were wrong from a long time ago per https://github.com/ironSource/parquetjs/issues/100

Solution
========
Updated the docs and added a simple test

Closes #106 