### PR TITLE
Add support for INT96 columns and large decimal columns

### DIFF
--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -874,7 +874,13 @@ async function decodeDictionaryPage(cursor: Cursor, header: parquet_thrift.PageH
     };
   }
 
-  return decodeValues(opts.column!.primitiveType!, opts.column!.encoding!, dictCursor, (header.dictionary_page_header!).num_values, opts)
+  return decodeValues(
+    opts.column!.primitiveType!,
+    opts.column!.encoding!,
+    dictCursor,
+    (header.dictionary_page_header!).num_values,
+    { ...opts, ...opts.column }
+  )
     .map((d:Array<unknown>) => d.toString());
 
 }

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -881,8 +881,6 @@ async function decodeDictionaryPage(cursor: Cursor, header: parquet_thrift.PageH
     (header.dictionary_page_header!).num_values,
     { ...opts, ...opts.column }
   )
-    .map((d:Array<unknown>) => d.toString());
-
 }
 
 async function decodeDataPage(cursor: Cursor, header: parquet_thrift.PageHeader, opts: Options) {


### PR DESCRIPTION
Problem
=======

When reading parquet files:
- INT96 columns are not being parsed correctly and are being truncated.
- Files with large DECIMAL columns stored in FIXED_LEN_BYTE_ARRAY is not supported

Solution
========

- Parses INT96 columns into a BigInt to return untruncated values.
- Adds support for parsing FIXED_LEN_BTYE_ARRAY columns into arbitrary precision DECIMALs.

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing
