### PR TITLE
Swap brotli dependency

### DIFF
--- a/lib/compression.ts
+++ b/lib/compression.ts
@@ -1,6 +1,6 @@
 import zlib from 'zlib'
 import snappy from 'snappyjs'
-import { compress as brotliCompress, decompress as brotliDecompress } from 'wasm-brotli'
+import { compress as brotliCompress, decompress as brotliDecompress } from 'brotli-wasm'
 
 type d_identity = (value: ArrayBuffer | Buffer | Uint8Array ) => ArrayBuffer | Buffer | Uint8Array
 type d_gzip = (value: ArrayBuffer | Buffer | string ) => Buffer
@@ -64,7 +64,7 @@ async function deflate_brotli(value: Uint8Array) {
     lgwin: 22
   }
   */)
-  
+
   return Buffer.from(compressedContent);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/long": "^4.0.2",
         "@types/node-int64": "^0.4.29",
         "@types/thrift": "^0.10.11",
+        "brotli-wasm": "^2.0.1",
         "browserify-zlib": "^0.2.0",
         "bson": "4.6.3",
         "cross-fetch": "^3.1.4",
@@ -21,7 +22,6 @@
         "snappyjs": "^0.6.1",
         "thrift": "0.16.0",
         "varint": "^6.0.0",
-        "wasm-brotli": "^2.0.2",
         "xxhash-wasm": "^1.0.2"
       },
       "devDependencies": {
@@ -2414,6 +2414,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli-wasm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-2.0.1.tgz",
+      "integrity": "sha512-+3USgYsC7bzb5yU0/p2HnnynZl0ak0E6uoIm4UW4Aby/8s8HFCq6NCfrrf1E9c3O8OCSzq3oYO1tUVqIi61Nww=="
+    },
     "node_modules/browser-or-node": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
@@ -4624,11 +4629,6 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
-    "node_modules/wasm-brotli": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/wasm-brotli/-/wasm-brotli-2.0.2.tgz",
-      "integrity": "sha512-DgjRlpZz9z5br4TjQHSlDHRF9NIuGXHUj3AqO08koDCXz7EYzmPDb7T/6oar5UKLYgPp9Yxc2ImGpx4BMFwbNQ=="
-    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -6664,6 +6664,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "brotli-wasm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-2.0.1.tgz",
+      "integrity": "sha512-+3USgYsC7bzb5yU0/p2HnnynZl0ak0E6uoIm4UW4Aby/8s8HFCq6NCfrrf1E9c3O8OCSzq3oYO1tUVqIi61Nww=="
+    },
     "browser-or-node": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
@@ -8289,11 +8294,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-    },
-    "wasm-brotli": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/wasm-brotli/-/wasm-brotli-2.0.2.tgz",
-      "integrity": "sha512-DgjRlpZz9z5br4TjQHSlDHRF9NIuGXHUj3AqO08koDCXz7EYzmPDb7T/6oar5UKLYgPp9Yxc2ImGpx4BMFwbNQ=="
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/long": "^4.0.2",
     "@types/node-int64": "^0.4.29",
     "@types/thrift": "^0.10.11",
+    "brotli-wasm": "^2.0.1",
     "browserify-zlib": "^0.2.0",
     "bson": "4.6.3",
     "cross-fetch": "^3.1.4",
@@ -27,7 +28,6 @@
     "snappyjs": "^0.6.1",
     "thrift": "0.16.0",
     "varint": "^6.0.0",
-    "wasm-brotli": "^2.0.2",
     "xxhash-wasm": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Per @ MaTiAtSIE via https://github.com/LibertyDSNP/parquetjs/issues/120#issuecomment-1997057706

Switch from the older, non-maintained [wasm-brotli](https://github.com/dfrankland/wasm-brotli) to the newer and maintained [brotli-wasm](https://github.com/httptoolkit/brotli-wasm).

Drop in swap, all tests still pass.

Closes #120 