### PR TITLE
Bump version of @zenfs/core to ^0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/long": "^4.0.2",
         "@types/node-int64": "^0.4.32",
         "@types/thrift": "^0.10.17",
-        "@zenfs/core": "^0.14.0",
+        "@zenfs/core": "^0.16.0",
         "brotli-wasm": "^3.0.0",
         "browserify-zlib": "^0.2.0",
         "bson": "6.7.0",
@@ -2629,9 +2629,9 @@
       "dev": true
     },
     "node_modules/@zenfs/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@zenfs/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-ongIf1uEu6NRVWRQDAUWbQ8xag5xQX+9XUnu9CuV89DjirUFIlTPLwnVRPXtTFB7aBdY3aThqthfplNXSAgEkg==",
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@zenfs/core/-/core-0.16.4.tgz",
+      "integrity": "sha512-QYT0tB3iHWo6q4KlSTl1zr2LWLgayNOHGPw5x+s926weH3Nrnw2Npe2gfLK05UFvXhhTynee8DgYGjFhgqBUmg==",
       "dependencies": {
         "@types/node": "^20.12.12",
         "@types/readable-stream": "^4.0.10",
@@ -2646,7 +2646,7 @@
         "make-index": "scripts/make-index.js"
       },
       "engines": {
-        "node": ">= 22"
+        "node": ">= 16"
       }
     },
     "node_modules/@zenfs/core/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/long": "^4.0.2",
     "@types/node-int64": "^0.4.32",
     "@types/thrift": "^0.10.17",
-    "@zenfs/core": "^0.14.0",
+    "@zenfs/core": "^0.16.0",
     "brotli-wasm": "^3.0.0",
     "browserify-zlib": "^0.2.0",
     "bson": "6.7.0",


### PR DESCRIPTION
- Previous version of zenfs-core had an engine requirement of >=22 which was higher than the engine requirement for this library (18.18.2) which caused issues with installing the library using yarn. (Yarn seemed to error on engine mismatch but trying it with npm just seemed to log a warning)

# Problem

In release 1.8.0 the browserfs dependency was replaced with zenfs (#134). This ^0.14.0 version has a engine requirement of 22, which has caused issues when I've tried to install this package in a node 18 project. The engine requirement for this library is 18.18.2.

Solution
========
In the 0.15.1 release of `@zenfs/core` they've added a polyfill and reduced the engine requirement to node 16. https://github.com/zen-fs/core/releases/tag/v0.15.1

I've bumped the version all the way to ^0.16.0 in case there were other fixes along the way. The rest of the changelogs can be seen: https://github.com/zen-fs/core/releases

You can see in the `package-lock.json` that the engine requirement has changed from 22 to 16.

## Change summary:

- Bump version of @zenfs/core to ^0.16.0
