### PR TITLE
Fix Metadata Statistics Comparison

### DIFF
--- a/lib/writer.ts
+++ b/lib/writer.ts
@@ -11,6 +11,7 @@ import { Options } from './codec/types';
 import { ParquetSchema } from './schema';
 import Int64 from 'node-int64';
 import SplitBlockBloomFilter from './bloom/sbbf';
+import { isUint8Array } from 'util/types';
 
 /**
  * Parquet File Magic String
@@ -415,6 +416,46 @@ function encodeStatistics(statistics: parquet_thrift.Statistics, column: Parquet
   return new parquet_thrift.Statistics(statistics);
 }
 
+function compareStatisticsBuffer<T extends Uint8Array>(
+  potential: T,
+  statistics: parquet_thrift.Statistics
+): { min_value?: T; max_value?: T } {
+  const result: { min_value?: T; max_value?: T } = {};
+  // === 1 means the first value is greater
+  if (statistics.max_value !== undefined && Buffer.compare(potential, statistics.max_value) === 1) {
+    result.max_value = potential;
+  }
+  // Flip the order for min
+  if (statistics.min_value !== undefined && Buffer.compare(statistics.min_value, potential) === 1) {
+    result.min_value = potential;
+  }
+  return result;
+}
+
+function compareStatisticsGtLt<T>(
+  potential: T,
+  statistics: parquet_thrift.Statistics
+): { min_value?: T; max_value?: T } {
+  const result: { min_value?: T; max_value?: T } = {};
+  // === 1 means the first value is greater
+  if (statistics.max_value !== undefined && potential > statistics.max_value) {
+    result.max_value = potential;
+  }
+  // Flip the order for min
+  if (statistics.min_value !== undefined && statistics.min_value > potential) {
+    result.min_value = potential;
+  }
+  return result;
+}
+
+function compareStatistics<T extends Uint8Array | number | string | bigint | boolean>(
+  potential: T,
+  statistics: parquet_thrift.Statistics
+): { min_value?: T; max_value?: T } {
+  if (isUint8Array(potential)) return compareStatisticsBuffer(potential, statistics);
+  return compareStatisticsGtLt(potential, statistics);
+}
+
 async function encodePages(
   schema: ParquetSchema,
   rowBuffer: parquet_shredder.RecordBuffer,
@@ -444,11 +485,13 @@ async function encodePages(
     if (field.statistics !== false) {
       statistics = {};
       [...values.distinct_values!].forEach((v, i) => {
-        if (i === 0 || v > statistics.max_value!) {
+        if (i === 0) {
           statistics.max_value = v;
-        }
-        if (i === 0 || v < statistics.min_value!) {
           statistics.min_value = v;
+        } else {
+          const { min_value, max_value } = compareStatistics(v, statistics);
+          if (min_value !== undefined) statistics.min_value = min_value;
+          if (max_value !== undefined) statistics.max_value = max_value;
         }
       });
 
@@ -656,11 +699,18 @@ async function encodeColumnChunk(
     const page = pages[i];
 
     if (opts.column.statistics !== false) {
-      if (page.statistics.max_value! > statistics.max_value! || i == 0) {
+      if (i === 0) {
         statistics.max_value = page.statistics.max_value;
-      }
-      if (page.statistics.min_value! < statistics.min_value! || i == 0) {
         statistics.min_value = page.statistics.min_value;
+      } else {
+        if (page.statistics.min_value !== undefined) {
+          const { min_value } = compareStatistics(page.statistics.min_value, statistics);
+          if (min_value !== undefined) statistics.min_value = min_value;
+        }
+        if (page.statistics.max_value !== undefined) {
+          const { max_value } = compareStatistics(page.statistics.max_value, statistics);
+          if (max_value !== undefined) statistics.max_value = max_value;
+        }
       }
       statistics.null_count.setValue(statistics.null_count.valueOf() + (page.statistics.null_count?.valueOf() || 0));
       page.distinct_values.forEach((value: unknown) => distinct_values.add(value));

--- a/test/metadataMinMax.test.ts
+++ b/test/metadataMinMax.test.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { ParquetSchema } from '../lib/schema';
+import { ParquetWriter } from '../lib/writer';
+import { ParquetReader } from '../lib/reader';
+
+describe('Metadata MinMax', function () {
+  describe('Buffer Comparison', function () {
+    it('correctly chooses the min and max', async function () {
+      const decimalSchema = new ParquetSchema({
+        rank: { type: 'DECIMAL' as const, precision: 20 },
+      });
+      const testFile = 'min-max-decimal.parquet';
+      const writer = await ParquetWriter.openFile(decimalSchema, testFile);
+
+      // These are the numbers for 10^15 + 127 through 10^15 + 129
+      const min = Buffer.from([0x00, 0x00, 0x03, 0x8d, 0x7e, 0xa4, 0xc6, 0x80, 0x7f]);
+      const mid = Buffer.from([0x00, 0x00, 0x03, 0x8d, 0x7e, 0xa4, 0xc6, 0x80, 0x80]);
+      const max = Buffer.from([0x00, 0x00, 0x03, 0x8d, 0x7e, 0xa4, 0xc6, 0x80, 0x81]);
+      await writer.appendRow({ rank: min });
+      await writer.appendRow({ rank: mid });
+      await writer.appendRow({ rank: max });
+      await writer.close();
+
+      const reader = await ParquetReader.openFile(testFile);
+
+      const stats = reader.metadata!.row_groups[0].columns[0].meta_data!.statistics;
+
+      expect(stats?.min).to.deep.equal(min);
+      expect(stats?.max).to.deep.equal(max);
+    });
+  });
+
+  describe('Integer Comparison', function () {
+    it('correctly chooses the min and max for Int64', async function () {
+      const intSchema = new ParquetSchema({
+        rank: { type: 'INT64' },
+      });
+      const testFile = 'min-max-int.parquet';
+      const writer = await ParquetWriter.openFile(intSchema, testFile);
+
+      const min = 100n;
+      const mid = 200n;
+      const max = 300n;
+      await writer.appendRow({ rank: min });
+      await writer.appendRow({ rank: mid });
+      await writer.appendRow({ rank: max });
+      await writer.close();
+
+      const reader = await ParquetReader.openFile(testFile);
+
+      const stats = reader.metadata!.row_groups[0].columns[0].meta_data!.statistics;
+
+      expect(stats?.min).to.deep.equal(min);
+      expect(stats?.max).to.deep.equal(max);
+    });
+  });
+
+  describe('String Comparison', function () {
+    it('correctly chooses the min and max for UTF8', async function () {
+      const intSchema = new ParquetSchema({
+        rank: { type: 'UTF8' },
+      });
+      const testFile = 'min-max-int.parquet';
+      const writer = await ParquetWriter.openFile(intSchema, testFile);
+
+      const min = 'A';
+      const mid = 'B';
+      const max = 'C';
+      await writer.appendRow({ rank: min });
+      await writer.appendRow({ rank: mid });
+      await writer.appendRow({ rank: max });
+      await writer.close();
+
+      const reader = await ParquetReader.openFile(testFile);
+
+      const stats = reader.metadata!.row_groups[0].columns[0].meta_data!.statistics;
+
+      expect(stats?.min).to.deep.equal(min);
+      expect(stats?.max).to.deep.equal(max);
+    });
+  });
+});


### PR DESCRIPTION
# Problem

Buffers were not correctly being compared causing incorrect statistics.

Closes #137 

Solution
========

Added buffer comparison separately from other `>` / `<` for statistics.

## Change summary:

- Added the test from #137 
- Fixed by adding `compareStatistics` which uses both `compareStatisticsGtLt` and what actually does the fix `compareStatisticsBuffer`
- Something else I/we did

## Steps to Verify:

1. See the test!